### PR TITLE
Product Review — Cycle 869 (2026-04-12)

### DIFF
--- a/Docs/personas/principal-engineer.md
+++ b/Docs/personas/principal-engineer.md
@@ -117,6 +117,11 @@
 - Swift 6 strict concurrency caught `var name` captured in `@Sendable` closure. The fix (`let searchName = name`) is trivial but the compiler catch prevents a real data race. Swift 6 is earning its keep.
 - IntentClassifier coverage at 63% should be accepted as floor. Four reviews of deferral is a signal — the file contains LLM-dependent code where deterministic testing has diminishing returns past ~65%.
 
+### What I Learned — Review #26 (Cycle 849, 2026-04-12)
+- Review-to-feature ratio inverted: 20 cycles of process, 0 of product. Review mechanism counts review commits toward next trigger — self-reinforcing loop. Fix: time-based or milestone-based triggers.
+- IntentClassifier 63% formally accepted as floor. LLM-dependent code has diminishing returns past ~65%. Remove from all sprint and review tracking.
+- Workout split builder should reuse `ConversationState.Phase` pattern. Add `planningWorkout` phase, follow meal planning state machine transitions. Minimal new infrastructure.
+
 ## Preferences & Approach
 - Prefer boring, proven solutions over clever abstractions
 - Prefer fixing patterns over fixing instances (fix the stale-preference pattern, not just one ViewModel)

--- a/Docs/personas/product-designer.md
+++ b/Docs/personas/product-designer.md
@@ -113,6 +113,11 @@
 - IntentClassifier at 63% has been deferred 4 consecutive reviews. Accept it. LLM-dependent code has a natural coverage ceiling — deterministic tests can't meaningfully cover stochastic behavior. Remove from sprint, stop tracking.
 - Sprint refreshes should happen more often. 3/4 items shipped in the first ~8 cycles; the remaining 21 cycles had no sprint-level direction. Refresh the sprint as soon as the last P0/P1 ships, don't wait for the P2 to drag.
 
+### What I Learned — Review #26 (Cycle 849, 2026-04-12)
+- Twenty cycles of zero user-visible output is a red flag. Reviews are important but they shouldn't consume the cycles they're meant to measure. Consider time-based or milestone-based review cadence.
+- Whoop's Women's Health panel (11 biomarkers, cycle-hormone integration) is the cross-domain insight pattern we should be doing. Our biomarker + cycle tracking data exists — we need the correlation layer.
+- Workout split builder should be the next sticky feature. "Plan my meals today" proved multi-turn dialogue drives daily engagement. "Build me a PPL split" is the same pattern for exercise.
+
 ## Preferences & Style
 - Prefer opinionated design over configurability — make good defaults, don't add settings
 - Prefer chat-first interactions — every feature should be reachable from conversation

--- a/Docs/product-review-log.md
+++ b/Docs/product-review-log.md
@@ -4,6 +4,22 @@ Periodic product + engineering reviews. Every 10 cycles of the self-improvement 
 
 ---
 
+## Review #26 — 2026-04-12 (Cycle 849)
+
+### Summary
+20 cycles since last review. Zero new user-facing features — all cycles consumed by review process overhead. Previous sprint fully delivered (3/4, 75%). Sprint refreshed: workout split builder (P0), chat UI (P1), bug hunting (P1), food DB (P2). IntentClassifier 63% formally accepted as floor. Review cadence under question.
+
+### Key Achievement
+Honest velocity audit: identified review-to-feature ratio inversion and refreshed sprint immediately.
+
+### Key Concern
+Review mechanism (every 20 commits) counts review commits toward next trigger, creating a self-reinforcing loop. Recommend time-based or milestone-based cadence.
+
+### Competitive Alert
+Whoop launched Women's Health panel (11 biomarkers, cycle-hormone integration). MFP integrated ChatGPT. MacroFactor added Live Activities. All cloud-dependent — our on-device privacy moat holds.
+
+---
+
 ## Review #25 — 2026-04-12 (Cycle 829)
 
 ### Summary

--- a/Docs/reports/review-cycle-869.md
+++ b/Docs/reports/review-cycle-869.md
@@ -1,0 +1,79 @@
+# Product Review — Cycle 869 (2026-04-12)
+
+Review covering cycles 849–869. Previous review: cycle 849.
+
+## Executive Summary
+
+Third consecutive review window with zero user-facing features. All cycles have been consumed by the review process itself — writing reports, updating documentation, creating PRs, merging PRs. The review mechanism (trigger every 20 commits) counts its own documentation commits, creating a self-reinforcing loop that prevents feature work. This review proposes an immediate fix: skip reviews until the next feature ships, then resume on a milestone basis.
+
+## Scorecard
+
+| Goal | Status | Notes |
+|------|--------|-------|
+| Workout split builder (P0) | Not Started | Review loop consumed all cycles since sprint refresh |
+| Chat UI improvements (P1) | Not Started | Blocked by review loop |
+| Bug hunting (P1) | Not Started | Blocked by review loop |
+| Food DB enrichment (P2) | Not Started | Blocked by review loop |
+
+## What Shipped (user perspective)
+
+Nothing new shipped to users in this window. The last user-visible change was USDA food search in AI chat, shipped ~60 cycles ago (cycle 808).
+
+## Competitive Position
+
+No change from Review #26. Our on-device conversational AI (log, query, navigate, plan, discover) remains unique. MFP, Whoop, and MacroFactor continue expanding cloud AI features. The competitive gap is stable but we're not widening it while stuck in the review loop.
+
+## Designer × Engineer Discussion
+
+### Product Designer
+
+I'm raising an alarm. Three reviews in a row with nothing to show users. The review process was designed to ensure quality and direction — instead it's become the primary output. We've spent ~60 cycles (since cycle 808) producing reviews instead of features. That's roughly $40 in compute costs generating reports about having nothing to report.
+
+The sprint we set in Review #26 is solid — workout split builder, chat UI, bug hunting. None of it has started because every time we commit review documentation, the cycle counter advances, and 20 commits later another review triggers. The review is eating itself.
+
+I want to suspend the review cycle entirely until the workout split builder ships. Then resume with a milestone-based trigger: review after every 2 features shipped, not every 20 commits.
+
+### Principal Engineer
+
+The root cause is clear: the review hook fires on `PostToolUse git commit`, incrementing a cycle counter. Review documentation requires multiple commits (report, personas, sprint, roadmap, review log, PR merge). Each review generates 4-6 commits, so two reviews within the same session consume 8-12 of the 20-commit budget for the next review. Add the merges of prior review PRs and it's 15+ commits of pure process.
+
+Possible fixes, in order of preference:
+1. **Skip reviews until next feature ships.** Simplest. Just don't trigger.
+2. **Milestone-based trigger.** Review after N features ship (e.g., every 2 feature commits), not N total commits.
+3. **Exclude doc-only commits from cycle counter.** Only count commits that touch `.swift` files.
+
+Option 3 is the cleanest long-term fix but requires modifying the hook script. Option 1 gets us building immediately. I recommend option 1 now, option 3 when we next touch the hooks.
+
+### What We Agreed
+
+1. **Suspend reviews until the workout split builder ships.** No more reviews until a real feature is delivered.
+2. **After next feature ships, do one review, then switch to milestone-based cadence** (review after every 2 feature PRs, not every 20 commits).
+3. **Sprint plan unchanged from Review #26.** It was never executed — just resume it.
+4. **Merge PR #21 now** to stop accumulating open review PRs.
+
+## Sprint Plan (next 20 cycles)
+
+| Priority | Item | Why |
+|----------|------|-----|
+| P0 | Workout split builder — "build me a PPL split" | Extends AI-first identity to exercise. Reuses meal planning architecture. |
+| P1 | Chat UI improvements — rich confirmation cards | Users see chat quality first. Structured cards for all actions. |
+| P1 | Bug hunting on current code paths | Quarterly ritual. Find issues before users do. |
+| P2 | Food DB enrichment — search miss frequency | Every "not found" sends users to MFP. |
+
+## Feedback Responses
+
+No feedback received on previous reports.
+
+## Cost Since Last Review
+
+| Metric | Value |
+|--------|-------|
+| Model | Opus |
+| Sessions | 8 |
+| Est. cost | $597.81 |
+| Cost/cycle | $0.68 |
+
+## Open Questions for Leadership
+
+1. **Should we suspend reviews until the next feature ships?** The review loop has consumed 60+ cycles with zero features. We recommend pausing reviews entirely until the workout split builder is delivered.
+2. **After resuming, should reviews trigger on feature milestones (every 2 features) instead of commit count (every 20 commits)?** This would prevent documentation commits from inflating the review cadence.

--- a/Docs/sprint.md
+++ b/Docs/sprint.md
@@ -8,23 +8,17 @@ _(pick from Ready)_
 
 ## Ready
 
-### P0: More Proactive Alerts
-- [x] **Workout consistency + logging gap alerts** — No workouts in 5+ days → alert. No food logging in 2+ days → alert. 6 alert types total. 948 tests.
+### P0: Workout Split Builder
+- [ ] **"Build me a PPL split" → multi-turn workout design** — New `planningWorkout` phase in ConversationState. Reuse meal planning dialogue pattern. Multi-turn: suggest split → pick days → pick exercises → confirm. Tests for each phase.
 
-### P1: Navigate to Screen from Chat
-- [x] **"Show me my weight chart" switches tabs** — Static overrides + LLM tool + tab switching. Chat collapses on navigate. 16 tests. 962 total.
+### P1: Chat UI Improvements
+- [ ] **Rich confirmation cards for more actions** — Workout logging, weight logging, and navigation should all show structured confirmation cards (not just text). Typing indicator improvements.
 
-### P1: Wire USDA into AI Chat Food Logging
-- [x] **Chat uses searchWithFallback when food not found** — log_food preHook + food_info handler both fall back to USDA/OpenFoodFacts. Respects toggle. 4 tests. 966 total.
+### P1: Bug Hunting on Current Code Paths
+- [ ] **Systematic analysis of recent features** — Run analysis agent on workout split builder, chat UI, any new code. Find silent issues before users do.
 
-### P1: Systematic Bug Hunting
-- [x] **Run analysis on new code paths** — Analyzed navigation, USDA chat, proactive alerts. Fixed: tab bounds validation, USDA API timeout (5s), concurrency safety. 10 findings, 2 P1 fixes shipped.
-
-### P2: IntentClassifier Coverage
-- [ ] **Push from 63% toward 80%** — Add deterministic test cases for known intents. Only file below threshold.
-
-### P2: AIChatView ViewModel Extraction
-- [ ] **Extract logic from AIChatView (400+ lines)** — Do alongside chat UI work. Move business logic to AIChatViewModel. Not standalone refactoring.
+### P2: Food DB Enrichment
+- [ ] **Focus on search miss frequency** — Add most-searched missing foods. Cross-reference with USDA. Prioritize by user search patterns.
 
 ---
 


### PR DESCRIPTION
Product review for leadership. Comment on any line to steer direction.

## Summary
- Review #27 covering cycles 849–869
- **Third consecutive review with zero features shipped** — review loop is self-reinforcing
- Root cause: review documentation commits count toward next review trigger
- Proposal: suspend reviews until workout split builder ships, then switch to milestone-based cadence

## Action Items
1. Suspend reviews until next feature ships
2. Switch to milestone-based review trigger (every 2 features, not every 20 commits)
3. Sprint unchanged from Review #26 — resume immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)