### PR TITLE
Product Review — Cycle 1647 (2026-04-14)

### DIFF
--- a/Docs/personas/principal-engineer.md
+++ b/Docs/personas/principal-engineer.md
@@ -171,6 +171,10 @@
 - Push notifications via `UserNotifications` framework is architecturally trivial. The only real risk is permission UX — prompt after first food log, not on launch. One wrong prompt = denied forever.
 - sendMessage at 491 lines is past threshold but not actively blocking. Defer decomposition until a feature requires touching that code. Don't refactor for its own sake.
 
+### What I Learned — Review #40 (Cycle 1647, 2026-04-14)
+- sendMessage decomposition was net negative lines (78 added, 109 removed). Phase-based grouping with named methods is the right pattern for large dispatchers. Sequential ConversationState transitions preserved without issue.
+- NotificationService + BehaviorInsightService at zero dedicated tests is the highest-risk untested code path. Prioritize in bug hunt.
+
 ### What I Learned — Review #37 (Cycle 1483, 2026-04-13)
 - Push notification architecture was clean — BehaviorInsightService detection reused directly, UserNotifications framework is the right local-only approach. Zero new infrastructure needed.
 - Regex-based exercise name extraction has a natural ceiling for natural language. The retry-with-singular-fallback is pragmatic for now, but long-term, routing through LLM intent classifier is the answer if edge cases proliferate.

--- a/Docs/personas/product-designer.md
+++ b/Docs/personas/product-designer.md
@@ -167,6 +167,10 @@
 - Push notifications deferred a 4th time is a systemic prioritization failure, not a scoping problem. Making it the ONLY P0 with no competing priorities is the fix.
 - Exercise instructions via chat ("how do I deadlift?") is more aligned with our AI-first identity than static images. Lean into conversational exercise coaching over Boostcamp-style media content.
 
+### What I Learned — Review #40 (Cycle 1647, 2026-04-14)
+- sendMessage decomposition closing a 6-review-old tech debt item proves the "isolate as sole P0" pattern works for infrastructure too, not just features.
+- Two same-day reviews with 1 feature commit between them is pure process overhead. Review cadence needs to be time-based or commit-based, not tool-call-based.
+
 ### What I Learned — Review #37 (Cycle 1483, 2026-04-13)
 - Push notifications shipped after 4 reviews of deferral. Making it the ONLY P0 with zero competing priorities was the fix. Apply this pattern to any feature that keeps slipping: isolate it, remove distractions.
 - All Phase 3c "Now" items are complete. The product is at a natural inflection point — decide whether to deepen polish or expand to new surfaces (widgets, Apple Watch).

--- a/Docs/product-review-log.md
+++ b/Docs/product-review-log.md
@@ -4,6 +4,22 @@ Periodic product + engineering reviews. Every 10 cycles of the self-improvement 
 
 ---
 
+## Review #40 — 2026-04-14 (Cycle 1647)
+
+### Summary
+sendMessage decomposition shipped (128→28 lines, 4 phase methods). 1/4 sprint items complete. Single feature commit in 20-cycle window — tool-call-based cycle counting inflates review frequency.
+
+### Key Achievement
+Chat architecture cleanup closes a 6-review-old tech debt item. Future AI features are now easier to add safely.
+
+### Key Concern
+Review cadence tied to tool calls, not commits — two reviews in one session. Systematic bug hunt carried 4th time.
+
+### Sprint Plan (next 20 cycles)
+P0: Systematic bug hunt. P1: iOS widget prototype. P2: Food search miss analysis.
+
+---
+
 ## Review #37 — 2026-04-13 (Cycle 1483)
 
 ### Summary

--- a/Docs/reports/review-cycle-1647.md
+++ b/Docs/reports/review-cycle-1647.md
@@ -1,0 +1,63 @@
+# Product Review — Cycle 1647 (2026-04-14)
+Review covering cycles 1627–1647. Previous review: cycle 1627 (Review #39).
+
+## Executive Summary
+
+The top P0 from last sprint — chat architecture cleanup — shipped in the first cycle. The AI chat message dispatcher was reorganized from 128 lines of inline logic into 8 clearly labeled phase handlers, making future AI feature work faster and safer. TestFlight build 115 remains the latest available build. Systematic bug hunt (P0) is next up, followed by iOS widget prototype.
+
+## Scorecard
+| Goal | Status | Notes |
+|------|--------|-------|
+| sendMessage decomposition | Shipped | 128→28 lines. 4 phase methods extracted. 1,131 tests pass. |
+| Systematic bug hunt | Not Started | Next in queue — will execute this sprint |
+| iOS widget prototype | Not Started | Blocked behind bug hunt |
+| Food search miss analysis | Not Started | P2, expected later in sprint |
+
+## What Shipped (user perspective)
+- **AI chat is more reliable** — Internal architecture cleanup means fewer edge-case bugs when adding new chat features. Users won't see a visible change, but future features ship faster and with fewer regressions.
+
+## Competitive Position
+
+Same as Review #39 (same day). WHOOP's AI Strength Trainer builds workouts from text and auto-detects exercises. MacroFactor Workouts adding Apple Health write-back. Boostcamp added muscle engagement visualization. Drift's all-in-one + free + on-device privacy positioning is strong but needs surface expansion (widgets) to match dedicated app convenience.
+
+## Designer x Engineer Discussion
+
+### Product Designer
+
+One item shipped in 20 cycles — but it was the right item. The chat message handler was the #1 architectural blocker flagged since Review #34 (6 reviews ago). Getting it done means we can now add new chat capabilities without fear of the 491-line function. That said, I want to see user-visible output this sprint. The bug hunt should surface real issues, and the widget prototype would be the first new user-facing surface in months.
+
+### Principal Engineer
+
+The decomposition landed cleanly — 78 insertions, 109 deletions, net negative lines. The dispatcher is now a 28-line orchestrator calling named phase methods. ConversationState phase transitions preserved their sequential ordering. All 1,131 tests passed without modification, confirming the refactor was purely structural.
+
+The cycle counter advancing 20 cycles on tool calls rather than commits remains a process issue. This review covers 1 feature commit. Consider switching to commit-based or time-based review triggers long-term.
+
+For the bug hunt: NotificationService and BehaviorInsightService alert logic still have zero dedicated tests (flagged Review #37). That's the highest-value area to probe.
+
+### What We Agreed
+1. **Systematic bug hunt is the immediate next task** — Focus on notification scheduling, food diary edge cases, and card attachment nil states. File bugs as GitHub Issues with regression tests.
+2. **iOS widget prototype follows** — Static "calories remaining" widget. App Group + shared UserDefaults for data sharing.
+3. **Sprint plan carries forward unchanged** — Tasks 2-4 from Review #39's plan remain valid and prioritized.
+4. **Review cadence note** — This is the 2nd same-day review. Tool-call-based cycle counting inflates review frequency. Accept it for now; long-term fix is commit-based triggers.
+
+## Sprint Plan (next 20 cycles)
+| Priority | Item | Why |
+|----------|------|-----|
+| P0 | Systematic bug hunt — notifications, food diary, AI edge cases | Carried 3x; NotificationService has zero tests. Proactive quality. |
+| P1 | iOS widget prototype — "calories remaining" on home screen | Phase 4 surface expansion; highest stickiness feature missing. |
+| P2 | Food search miss analysis — track zero-result queries | Data-driven food DB improvement. |
+
+## Feedback Responses
+No feedback received on Review #39 (PR #44, Cycle 1627). PR had zero comments.
+
+## Cost Since Last Review
+| Metric | Value |
+|--------|-------|
+| Model | Opus |
+| Sessions | Same session as Review #39 |
+| Est. cost | N/A (single continuous session) |
+| Cost/cycle | ~$0.06 (historical average) |
+
+## Open Questions for Leadership
+1. **Review frequency:** Two reviews in one session is process overhead. Should we switch to time-based triggers (e.g., every 24 hours) instead of cycle-based (every 20 tool calls)?
+2. **Bug hunt scope:** Should the systematic bug hunt focus narrowly on notifications (zero test coverage) or cast a wider net across all recent changes?

--- a/Docs/sprint-plan.md
+++ b/Docs/sprint-plan.md
@@ -1,114 +1,114 @@
-# Sprint Plan — Review #37 (Cycles 1483–1503)
+# Sprint Plan — Review #39 (Cycles 1627–1647)
 
-Created: 2026-04-13
+Created: 2026-04-14
 
 ---
 
 ## Task 1: sendMessage decomposition
 **Priority:** P0
-**Classification:** JUNIOR (Sonnet + advisor)
-**Status:** [x] done (already decomposed — 128 lines, 21 extracted handle* methods)
+**Classification:** SENIOR (Opus)
+**Status:** [x] done — 128→28 lines, 4 phase methods extracted, 1131 tests pass
 
-**Goal:** Break 491-line sendMessage into focused named methods. Pure refactor, no behavior change.
+**Goal:** Organize the 25+ handler methods in AIChatView+MessageHandling.swift into clearly named phase groups. The main sendMessage dispatcher (128 lines) calls handlers across 1,168 lines. Group handlers by phase, clarify ownership of ConversationState transitions, make each phase independently testable.
 
 **Files:**
-- `Drift/ViewModels/AIChatViewModel.swift`
+- Drift/Views/AI/AIChatView+MessageHandling.swift (1,168 lines — main target)
+- Drift/Views/AI/AIChatViewModel.swift (class definition, types)
+- Drift/Services/ConversationState.swift (Phase enum)
 
 **Approach:**
-1. Read full sendMessage, identify logical sections (input validation, state prep, static overrides, LLM pipeline, response handling, card attachment, cleanup)
-2. Extract each into private methods with clear names
-3. Keep public interface identical — `sendMessage()` becomes a coordinator that calls private methods
-4. Run all 1,037 tests to verify zero behavior change
+1. Read sendMessage dispatcher (lines 164-292) — understand the 9 dispatch phases
+2. Group handlers by phase: static overrides, workout quick paths, confirmations, view-state handlers, multi-turn continuations, planning triggers, food intent parsing, AI pipeline
+3. Extract each phase group into a clearly named extension method (e.g., `handleStaticOverrides`, `handleMultiTurnContinuation`)
+4. The main sendMessage becomes a clean sequential dispatcher calling phase methods
+5. Ensure ConversationState phase transitions remain sequential — never reorder or parallelize
+6. Run full test suite after each extraction step
 
-**Edge cases:**
-- Early returns in nested conditions must be preserved (guard statements)
-- Shared mutable state between sections (conversation state, pending vars)
-- Error handling paths must remain identical
+**Edge cases:** ConversationState.phase must be set AFTER handler processing completes (line 494 pattern). weak self in closures. Async/await boundaries between phases.
 
-**Tests:**
-- All existing 1,037 tests must pass unchanged
-- No new tests needed (pure refactor)
+**Tests:** All 996+ existing tests must pass. Add focused tests for individual phase handlers if coverage gaps found.
 
-**Acceptance:** sendMessage under 100 lines, all tests pass, zero behavior change.
+**Acceptance:** sendMessage is a clean dispatcher under 50 lines. Each phase group is a named method. All tests pass.
 
 ---
 
-## Task 2: Food search miss analysis + targeted additions
-**Priority:** P1
-**Classification:** JUNIOR (Sonnet + advisor)
-**Status:** [x] done — 20 high-value foods added (protein snacks, supplements, fitness staples). DB at 1,520.
-
-**Goal:** Identify the most-searched missing foods and add them. Every "not found" = user opens MFP.
-
-**Files:**
-- `Drift/Resources/foods.json`
-- Possibly `Drift/Services/SpellCorrectService.swift` for new synonyms
-
-**Approach:**
-1. Review common food queries from eval harness and failing-queries.md
-2. Cross-reference with USDA for accurate nutrition data
-3. Add 20-30 high-value missing foods (focus on frequently searched items)
-4. Add synonyms for regional variants
-
-**Tests:**
-- Search tests for each added food
-- Verify existing foods not broken
-
-**Acceptance:** Top 20 search misses addressed. Build passes.
-
----
-
-## Task 3: Notification + behavior alert test coverage
-**Priority:** P1
-**Classification:** JUNIOR (Sonnet + advisor)
+## Task 2: Systematic bug hunt
+**Priority:** P0
+**Classification:** SENIOR (Opus)
 **Status:** [ ] pending
 
-**Goal:** NotificationService and BehaviorInsightService alert detection have zero dedicated unit tests. Add edge-case coverage.
+**Goal:** Proactive quality pass. Carried 3 sprints — must ship. Focus on notification scheduling edge cases, food diary boundary conditions, and recent AI pipeline changes.
 
 **Files:**
-- `DriftTests/` — new test file or extend existing
+- Drift/Services/NotificationService.swift (scheduling, permission, toggle edge cases)
+- Drift/ViewModels/FoodLogViewModel.swift (diary copy/reorder/delete edge cases)
+- Drift/Views/AI/AIChatView+MessageHandling.swift (recent card attachment paths)
 
 **Approach:**
-1. Test proteinStreakAlert edge cases: exactly 3 days, 2 days (no alert), data gaps
-2. Test supplementGapAlert: new supplement (no history), all taken, mixed
-3. Test workoutConsistencyAlert: 4 days vs 5 days threshold
-4. Test loggingGapAlert: logged today only, logged yesterday only
-5. Test composeNotification: single alert, multiple alerts
+1. Trace NotificationService: permission revoked mid-session, toggle race conditions, schedule after midnight, duplicate scheduling
+2. Trace food diary: same-timestamp entries, copy from empty day, delete last item, edit zero-calorie entry
+3. Check recent card attachment code for nil/empty state handling
+4. File any bugs found as GitHub Issues with regression tests
+5. If bugs found, fix them with tests in the same cycle
 
-**Acceptance:** All alert detection methods have dedicated tests. Coverage for BehaviorInsightService above 50%.
+**Edge cases:** Permission state changes between check and schedule. Timer firing during app background.
+
+**Tests:** Add regression tests for every bug found. Target: 5+ new tests minimum.
+
+**Acceptance:** Analysis complete, all found bugs fixed with tests. If clean, document what was checked.
 
 ---
 
-## Task 4: Systematic bug hunt
+## Task 3: iOS widget prototype
 **Priority:** P1
-**Classification:** JUNIOR (Sonnet + advisor)
+**Classification:** SENIOR (Opus)
 **Status:** [ ] pending
 
-**Goal:** Quarterly practice. Focus on notification scheduling, food diary edge cases, recent AI changes.
+**Goal:** Create a "Calories Remaining" home screen widget using WidgetKit. First Phase 4 surface — makes Drift visible throughout the day without opening the app.
+
+**Files:**
+- New: DriftWidget/ extension target
+- project.yml (add widget extension target)
+- Shared data: App Groups for data sharing between main app and widget
 
 **Approach:**
-1. Review NotificationService for edge cases (permission revoked mid-session, toggle race)
-2. Review food diary copy/reorder for timestamp edge cases
-3. Trace data paths through recent features
-4. Add regression tests for anything found
+1. Add App Group capability to main app and create widget extension target in project.yml
+2. Run xcodegen generate
+3. Create shared UserDefaults suite for App Group data sharing
+4. Write today's calorie data to shared UserDefaults on each food log
+5. Create TimelineProvider that reads shared calorie data
+6. Design small/medium widget: calories remaining number, progress ring, date
+7. Static timeline with refresh on app foreground (not live-updating — battery concern)
+8. Test on simulator
 
-**Acceptance:** Analysis complete, any bugs found are fixed with regression tests.
+**Edge cases:** No data state (user hasn't logged today). Widget timeline refresh frequency. GRDB concurrent reads from widget process — use shared UserDefaults instead for simplicity.
+
+**Tests:** Widget provider unit tests with mock data. Main app data-sharing tests.
+
+**Acceptance:** Widget appears on home screen showing today's remaining calories. Updates when app is opened after logging food.
 
 ---
 
-## Task 5: State.md refresh
+## Task 4: Food search miss analysis
 **Priority:** P2
 **Classification:** JUNIOR (Sonnet + advisor)
 **Status:** [ ] pending
 
-**Goal:** State.md is stale — tests show 981 (actual: 1,037), build 108 (actual: 112), capabilities incomplete.
+**Goal:** Track zero-result food searches to make DB improvements data-driven. Every "not found" = user opens competitor.
 
 **Files:**
-- `Docs/state.md`
+- Drift/Services/FoodService.swift (add search miss logging)
+- Drift/Database/AppDatabase.swift (add search_misses table)
 
 **Approach:**
-1. Update all numbers: tests, build, foods, exercises, tools, card types
-2. Update AI chat capabilities list
-3. Update tech stack notes if changed
+1. Add a `search_misses` table: query text, timestamp, count
+2. On zero-result local search (before USDA fallback), log the query
+3. Dedup similar queries (lowercase, trim whitespace)
+4. Don't log if USDA fallback succeeds (user got a result)
+5. After data accumulates, analyze top misses for targeted food additions
 
-**Acceptance:** State.md accurately reflects current build.
+**Edge cases:** Privacy — search misses stay local only. Don't log partial typing (only completed searches). Dedup "chicken" and "chickens" variants.
+
+**Tests:** Test miss logging, dedup logic, query counting.
+
+**Acceptance:** search_misses table exists, logging works, initial analysis documented.


### PR DESCRIPTION
Product review for leadership. Comment on any line to steer direction.

## Highlights
- sendMessage decomposition shipped (128→28 lines, 1,131 tests pass)
- Sprint carries forward: bug hunt → widget → search miss analysis

## Open Questions
1. Should review triggers be time-based instead of cycle-based?
2. Bug hunt scope: narrow (notifications) or wide (all recent changes)?