### PR TITLE
Design #274: Exercise video curation + muscle-highlight visuals

### DIFF
--- a/Docs/designs/274-youtube-curation-muscle-views.md
+++ b/Docs/designs/274-youtube-curation-muscle-views.md
@@ -1,0 +1,126 @@
+# Design: Exercise Video Curation + Muscle-Focused Visuals
+
+> References: Issue #274 | Related prior art: #133 (exercise-enrichment), Docs/designs/133-exercise-enrichment.md
+
+## Problem
+
+Users who open an exercise detail today see a static JPG from the free-exercise-db thumbnail (932/966 exercises have one) and — for 33 cherry-picked exercises — a YouTube link. The gap has two shapes:
+
+1. **Video coverage is thin.** Only 33 of ~966 exercises (~3%) link to a demo video. The long tail (hip thrust variations, cable machine attachments, mobility drills) gives users a still image and nothing else.
+2. **A still image doesn't show the working muscle.** The user's request is more specific than "more videos": they want the *muscle in motion* — a skeleton/figure animation with the target muscle highlighted. That's a different visual primitive than a YouTube demo. A demo shows form; a muscle-highlight animation shows *what's being trained*.
+
+These are related but distinct. A good design has to decide where each one fits in the exercise detail view, and how to produce the content without a paid team of animators.
+
+Affected surface: `ExerciseDetailView` (Drift/Views/Workout/ExerciseBrowserView.swift:185), `ExerciseInfo` (Drift/Services/ExerciseDatabase.swift:5), `exercises.json`.
+
+## Proposal
+
+Two parallel tracks, both driven by a small amount of one-time curation work, no runtime API calls, no cloud.
+
+**Track A — YouTube curation expansion.** Grow `youtubeUrl` coverage from 33 → ~300 (the exercises that account for >95% of user logs in a typical strength program). Manual curation, stored as flat URLs in `exercises.json`, opened via `SFSafariViewController` (already wired). Scope-boxed by a priority list.
+
+**Track B — Muscle-highlight visual.** Render a simple front+back anatomy figure with the primary muscle(s) tinted, **computed from the `primaryMuscles` field we already have**. Not fetched, not stored as an asset — drawn live from an SF-Symbols-style vector body map. Zero per-exercise curation work: every one of the 966 exercises gets a muscle diagram automatically. This is the biggest leverage point.
+
+Out of scope: licensed 3D animations (expensive, no open source with permissive licensing, violates offline-first), on-device video generation (too slow on A19), per-user custom form videos.
+
+## UX Flow
+
+### Exercise Detail (post-change)
+
+```
+┌────────────────────────────────────┐
+│   [Bench Press]                    │
+│                                    │
+│   ┌──────────┬──────────┐          │  ← New muscle-highlight card
+│   │  FRONT   │   BACK   │          │    (Track B — every exercise)
+│   │  figure  │  figure  │          │
+│   │ (chest   │ (tinted  │          │
+│   │ tinted)  │ nothing) │          │
+│   └──────────┴──────────┘          │
+│   Targets: Pectoralis Major        │
+│   Assists: Front Delts, Triceps    │
+│                                    │
+│   [ Watch form video ▶ ]           │  ← Track A — if youtubeUrl present
+│                                    │
+│   [Thumbnail GIF/JPG] (existing)   │
+│                                    │
+│   Equipment · Level · Category     │
+└────────────────────────────────────┘
+```
+
+Priority ordering: **muscle card first** (always present, no network), **video second** (opt-in, requires network), **thumbnail last** (legacy). If the muscle card renders, the thumbnail JPG becomes less necessary; we keep it for now to smooth the rollout.
+
+### AI chat integration
+
+When the AI explains "what muscles does the bench press work", it can reference the same muscle-highlight image by issuing a `showMuscleMap(exercise:)` tool call — no separate asset fetch needed.
+
+```
+User: "what does bench press work?"
+AI: "Bench press primarily trains your pectoralis major, with front delts and
+     triceps assisting. Here's the muscle map:" [renders muscle card]
+```
+
+## Technical Approach
+
+### Track A — YouTube curation (the "how to curate" question)
+
+**Source of truth.** Extend `exercises.json` in-place with a `youtubeUrl` field (already optional in `ExerciseInfo`). No new tables, no new files, no new fetches.
+
+**Curation process** (one-time, repeatable):
+
+1. Rank exercises by expected frequency using the existing `free-exercise-db` category/equipment distribution plus the logged-exercise data we already track (table `workout_exercise_usage` via `ExerciseService`). Take the top 300.
+2. For each exercise, the curator searches YouTube for `"{exercise name} proper form"` and picks from a pre-vetted channel allowlist: Alan Thrall, Jeff Nippard, Renaissance Periodization, Athlean-X, Squat University, Mind Pump. These are quality-stable and embed-friendly.
+3. Paste the watch URL directly into `exercises.json`. Use full `https://www.youtube.com/watch?v=...` form (not shortened) — parses reliably with `URL(string:)`.
+4. Commit in batches of 50. Each batch is one PR so review is tractable.
+
+**Tooling to make this less painful.** A small CLI `scripts/exercise-video-curate.py`:
+- Reads `exercises.json`, filters to entries missing `youtubeUrl` in the top-N list.
+- For each, opens a YouTube search in the default browser (`open`) and prompts for a URL.
+- Writes back in sorted, formatted JSON so diffs stay clean.
+- 300 entries × ~30s each = ~2.5 hours of curator time. Doable in a few sessions.
+
+**What we do NOT do:** no YouTube Data API, no server, no periodic sync. The links are static JSON shipped with the app.
+
+### Track B — Muscle-highlight visual (the real win)
+
+**Rendering primitive.** A SwiftUI view `MuscleHighlightView(primary: [MuscleGroup], secondary: [MuscleGroup])` that draws two body silhouettes (front + back) with Path/Shape, tinted per muscle group. Implementation options ranked by effort:
+
+1. **SVG body map → SwiftUI `Path`** (recommended). Use a free anatomy SVG like the ones from `musclewiki` (CC-BY) or `exrx` (check license). Split into ~30 named paths (one per muscle group). At runtime, union the paths corresponding to `primaryMuscles` and fill them with `Theme.accent`; secondary muscles get `Theme.accent.opacity(0.4)`. All other paths stay muted.
+2. **Pre-rendered PNG atlases.** Ship one front + one back master image, one PNG mask per muscle group (~25 masks × ~10KB = 250KB asset budget). Composite at runtime. Simpler than paths but bigger binary.
+3. **SceneKit 3D model.** Out of scope — too heavy, binary blowup, rendering inconsistency across devices.
+
+Recommendation: **option 1**. The Exercise model's `primaryMuscles` field (already populated for all 966 exercises) maps directly to the named SVG paths. Matching free-exercise-db's muscle taxonomy (`chest`, `lats`, `traps`, `hamstrings`, …) to the SVG's muscle paths is a one-time ~30-line lookup table. After that, every exercise lights up correctly with no per-exercise work.
+
+**Animation (optional stretch).** Start static. The user's ask mentions "skeleton doing exercises" — true motion animation is a much bigger ask (custom per-exercise keyframes, rigging). Starting with a static *muscle highlight* delivers ~80% of the pedagogical value at <5% of the cost. If usage shows people wanting motion, revisit with a focused Lottie-based approach on the top 30 lifts.
+
+**Files/services touched.**
+- New: `Drift/Views/Workout/MuscleHighlightView.swift` — the vector-body SwiftUI view.
+- New: `Drift/Resources/body-map.svg` + parser helper (or hardcoded Path arrays if small enough).
+- New: `Drift/Services/MuscleMapping.swift` — maps free-exercise-db muscle strings to SVG path names.
+- Edit: `ExerciseBrowserView.swift:185` (`ExerciseDetailView`) — insert the card above the existing thumbnail.
+- Edit: `Docs/tools.md` + `AIToolAgent.swift` — register `showMuscleMap` tool.
+
+**Dual-model fit.** SmolLM doesn't call tools, so the muscle-map tool lives in Gemma's toolset. SmolLM users still see the card in `ExerciseDetailView` — the visual is independent of the LLM.
+
+**Performance.** Draw once on appear, no network, no cache. <16ms on a mid-tier iPhone for two vector silhouettes with ~30 paths each.
+
+## Edge Cases
+
+- **Exercises with no primary muscle** (e.g., generic "Cardio"). Render a grayed-out body with a "full-body / cardio" label instead of empty tint.
+- **Compound lifts with many primary muscles** (e.g., deadlift). Highlight *all* primary muscles; designer picks a visual saturation that stays readable with 4–5 muscles lit.
+- **Stretches and mobility drills** that target soft tissue (fascia, ligaments). Fall back to a single-color tint on the involved region — label reads "mobility/stretch" so expectation is set.
+- **YouTube URL rot.** Videos get taken down. Track A accepts this — missing video = just no play button. No fallback needed; the muscle card carries the weight.
+- **Muscle name mismatches.** free-exercise-db uses lower-case plain-English (`"lower back"`); SVG paths might use Latin (`"erector_spinae"`). The mapping table handles the translation; any unmapped name logs once and falls through to "primary muscle" generic.
+- **Kids' / adaptive users.** Body silhouette is a neutral adult outline; we should pick an SVG that doesn't look gendered or hyper-muscled. A "basic athletic" figure reads best.
+
+## Open Questions
+
+1. **Curator.** Who curates the 300 YouTube URLs? If it's the founder (ashish-sadh), ~2.5h of work split across sessions. If it's delegated, we need a channel allowlist + a rubric for "good form video" (no ads in first 10s, clear angle, no overdub music).
+2. **License for the body-map SVG.** Preferred candidates: `musclewiki-icons` (CC-BY), Wikimedia Commons' "Gray's Anatomy" line art (public domain but dated aesthetic), `BioDigital` (paid). Need to confirm CC-BY is acceptable with one-line attribution in About.
+3. **Secondary muscle visibility.** Do we tint secondary muscles at a lower opacity, or omit them entirely? Proposal: tint at 40% — it lets users see assist patterns, but falls behind the primary. Easy to dial after the first usable build.
+4. **Where does the muscle card live for AI chat?** Inline in chat as an image bubble, or as a tap-through sheet? Proposal: inline in chat (under 120pt tall), tap expands to full detail. Matches the existing nutrition-lookup card pattern.
+5. **Ordering of the tracks.** Track B (muscle card) is higher leverage — it covers all 966 exercises once, versus Track A which covers 300 with ongoing curation. Proposal: **ship Track B first**, then Track A in a follow-up sprint.
+
+---
+
+*To approve: add `approved` label to the PR. To request changes: comment on the PR.*

--- a/Drift.xcodeproj/project.pbxproj
+++ b/Drift.xcodeproj/project.pbxproj
@@ -247,9 +247,11 @@
 		E0F86EB4273E7AC079F525CE /* LabReportOCR.swift in Sources */ = {isa = PBXBuildFile; fileRef = E342C8090873CF9612C8A63E /* LabReportOCR.swift */; };
 		E10A3A33C9E718C1D077AC02 /* WeightEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 217B3F5DA6C6AA9BB267D9F3 /* WeightEntryView.swift */; };
 		E16388BC43C225F2C6B7368A /* AIChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FA2C56E731BE5610FDC5B12 /* AIChatView.swift */; };
+		E19A1D1FE5326EACA1C51253 /* VoiceTranscriptionPostFixerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5AA88C83E11DABCCFDAF6C4 /* VoiceTranscriptionPostFixerTests.swift */; };
 		E220B46BAB957B8242ABA44A /* IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24EBC73AF46E92F7FF6A10FF /* IntegrationTests.swift */; };
 		E312846BA4FBD129108D7C82 /* ExerciseBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21311CD0AE82F339C988BDD2 /* ExerciseBrowserView.swift */; };
 		E3CEF38E5F1D8E62C22B5543 /* FoodLogSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029FE8C8F52268339F742BFA /* FoodLogSheet.swift */; };
+		E4974A05B377874B21A75D5D /* VoiceTranscriptionPostFixer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63172D2C1A90AA26AF409CEA /* VoiceTranscriptionPostFixer.swift */; };
 		E5611698773A5EEF24F10014 /* EditFoodEntrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F30EC2EF2E12E44F63B37582 /* EditFoodEntrySheet.swift */; };
 		E5C9ACF7CCAED656F70B23F9 /* PhotoLogReviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19A30BB3C9CCE28A9A758EF /* PhotoLogReviewView.swift */; };
 		E63F9BB35572B3EF11BF9DE5 /* HardEvalSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DEC3049742676C1201A6847 /* HardEvalSet.swift */; };
@@ -446,6 +448,7 @@
 		5DAC7F3DE02D237C91936A3C /* FoodServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodServiceTests.swift; sourceTree = "<group>"; };
 		5F6D2AA89F46A33EAE39DEAC /* MoreTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreTabView.swift; sourceTree = "<group>"; };
 		62E7E108AC25A8262DC23EB7 /* AppDatabase+FoodUsage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDatabase+FoodUsage.swift"; sourceTree = "<group>"; };
+		63172D2C1A90AA26AF409CEA /* VoiceTranscriptionPostFixer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTranscriptionPostFixer.swift; sourceTree = "<group>"; };
 		647116F9E4F78CE702CB870C /* RobustnessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RobustnessTests.swift; sourceTree = "<group>"; };
 		64BFDDB952907C50869B4078 /* AIBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIBackend.swift; sourceTree = "<group>"; };
 		64C160A33FFEF2C185DA06ED /* IntentClassifierGoldSetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentClassifierGoldSetTests.swift; sourceTree = "<group>"; };
@@ -582,6 +585,7 @@
 		E38FF7C7D3E9C7AED0CC8F83 /* WeightServiceAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightServiceAPI.swift; sourceTree = "<group>"; };
 		E4B60275240AEDD1A676B282 /* ConversationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationState.swift; sourceTree = "<group>"; };
 		E4BD88646DFE4A17724D4407 /* AddSupplementView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddSupplementView.swift; sourceTree = "<group>"; };
+		E5AA88C83E11DABCCFDAF6C4 /* VoiceTranscriptionPostFixerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceTranscriptionPostFixerTests.swift; sourceTree = "<group>"; };
 		E63B0B98A699C56CBC8944B1 /* RecentEntriesWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentEntriesWindowTests.swift; sourceTree = "<group>"; };
 		E6B95CCD0C984C915051F482 /* sample_lingo_export.csv */ = {isa = PBXFileReference; path = sample_lingo_export.csv; sourceTree = "<group>"; };
 		E6C4AF4636637C2EF46CD085 /* ConversationStatePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStatePersistenceTests.swift; sourceTree = "<group>"; };
@@ -787,6 +791,7 @@
 				40634DDEB9C53BD0146A628A /* TDEEEstimatorTests.swift */,
 				E1A5DA3E3543A99260250279 /* UIFlowTests.swift */,
 				EDAD5133BD684B10BEDC1131 /* USDAFallbackTests.swift */,
+				E5AA88C83E11DABCCFDAF6C4 /* VoiceTranscriptionPostFixerTests.swift */,
 				550B90AE65B6BF4C31B62382 /* WeeklySummaryRoutingTests.swift */,
 				BED47C488D5D052F183327F8 /* WeightServiceAPITests.swift */,
 				3F51E9EC49412B4F96068D35 /* WeightTrendCalculatorTests.swift */,
@@ -1085,6 +1090,7 @@
 				7F42EA4B9416215EFE670984 /* ToolRegistration.swift */,
 				C170D4FEDFB68CA8A61E1D03 /* ToolSchema.swift */,
 				1EEA23E4C1755C342030C667 /* USDAFoodService.swift */,
+				63172D2C1A90AA26AF409CEA /* VoiceTranscriptionPostFixer.swift */,
 				E38FF7C7D3E9C7AED0CC8F83 /* WeightServiceAPI.swift */,
 				FD5DFCD5C5ED2C0D7E5CD8EF /* WeightTrendCalculator.swift */,
 				AF522FED101388047FEE98FD /* WeightTrendService.swift */,
@@ -1479,6 +1485,7 @@
 				07703998EC9E02AD418576E8 /* TypingDotsView.swift in Sources */,
 				B47A39B47130D32625A50BE0 /* USDAFoodService.swift in Sources */,
 				9CBCD31AD1998B4E5237C1A6 /* Units.swift in Sources */,
+				E4974A05B377874B21A75D5D /* VoiceTranscriptionPostFixer.swift in Sources */,
 				DFFA7CC42D60E67CB40222E8 /* WeightChartView.swift in Sources */,
 				7BDC02B8C99F8B719546A8A1 /* WeightEntry.swift in Sources */,
 				E10A3A33C9E718C1D077AC02 /* WeightEntryView.swift in Sources */,
@@ -1585,6 +1592,7 @@
 				923230686AD033F5F7025F94 /* TDEEEstimatorTests.swift in Sources */,
 				98FF97CFE71A6BBCFF976259 /* UIFlowTests.swift in Sources */,
 				11DB8618758D582670EBF2F8 /* USDAFallbackTests.swift in Sources */,
+				E19A1D1FE5326EACA1C51253 /* VoiceTranscriptionPostFixerTests.swift in Sources */,
 				CA3F2052B0B3E9E56D7AF064 /* WeeklySummaryRoutingTests.swift in Sources */,
 				CBACE89C978AA0377081831E /* WeightServiceAPITests.swift in Sources */,
 				DF025680665178535364944C /* WeightTrendCalculatorTests.swift in Sources */,
@@ -1721,7 +1729,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = DriftWidget/DriftWidget.entitlements;
-				CURRENT_PROJECT_VERSION = 155;
+				CURRENT_PROJECT_VERSION = 156;
 				DEVELOPMENT_TEAM = ZJ5H5XH82A;
 				INFOPLIST_FILE = DriftWidget/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1741,7 +1749,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = DriftWidget/DriftWidget.entitlements;
-				CURRENT_PROJECT_VERSION = 155;
+				CURRENT_PROJECT_VERSION = 156;
 				DEVELOPMENT_TEAM = ZJ5H5XH82A;
 				INFOPLIST_FILE = DriftWidget/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1799,7 +1807,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Drift/Drift.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 155;
+				CURRENT_PROJECT_VERSION = 156;
 				DEVELOPMENT_TEAM = ZJ5H5XH82A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1932,7 +1940,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Drift/Drift.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 155;
+				CURRENT_PROJECT_VERSION = 156;
 				DEVELOPMENT_TEAM = ZJ5H5XH82A;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Drift.xcodeproj/project.pbxproj
+++ b/Drift.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		923230686AD033F5F7025F94 /* TDEEEstimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40634DDEB9C53BD0146A628A /* TDEEEstimatorTests.swift */; };
 		92B596C732C7784167EC8CDE /* WorkoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A884AC137C46CE932FEE1C9 /* WorkoutTests.swift */; };
 		92F6CD33F11BF82738AAF81C /* LabReportOCRTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1E187818C8B9D2196B4B9D /* LabReportOCRTests.swift */; };
+		935DC53E0F668379205DEC4D /* ModelParityEval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2901453F1C85FD9FB34FA9E3 /* ModelParityEval.swift */; };
 		93791225B1B385B9611CB503 /* DEXAService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 706EF63B663E60DF825752E3 /* DEXAService.swift */; };
 		940612EB003CCC2F1FF36DD1 /* AIEvalHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADD153523D188C4ED89B55D /* AIEvalHarness.swift */; };
 		94F5CD3A73D0EAA80DCEA612 /* ConversationStatePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C4AF4636637C2EF46CD085 /* ConversationStatePersistenceTests.swift */; };
@@ -390,6 +391,7 @@
 		24385DF0FF7F89584AE40020 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		24EBC73AF46E92F7FF6A10FF /* IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegrationTests.swift; sourceTree = "<group>"; };
 		2662F38D09EED0C1C9415508 /* PhotoLogCaptureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLogCaptureView.swift; sourceTree = "<group>"; };
+		2901453F1C85FD9FB34FA9E3 /* ModelParityEval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelParityEval.swift; sourceTree = "<group>"; };
 		2A19AD32FF007540A79C20BC /* AppDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDatabase.swift; sourceTree = "<group>"; };
 		2CFE343BFAFCD99118098211 /* AIToolAgent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToolAgent.swift; sourceTree = "<group>"; };
 		2D4B47196E8598EB15359D7C /* SupplementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupplementService.swift; sourceTree = "<group>"; };
@@ -764,6 +766,7 @@
 				5D1E187818C8B9D2196B4B9D /* LabReportOCRTests.swift */,
 				9F6585ACE94D5E5C51F74AE7 /* MacroFormattersTests.swift */,
 				358B9AF32E9AE57D1A7DF354 /* MealTypeDetectionTests.swift */,
+				2901453F1C85FD9FB34FA9E3 /* ModelParityEval.swift */,
 				48395DCDA65A417FF1BCC401 /* MultiTurnContextTests.swift */,
 				9C87F6B55BFF5055B77C57C1 /* NormalizerGoldSetTests.swift */,
 				F86B648E00469832A2C8FB56 /* NotificationServiceTests.swift */,
@@ -1561,6 +1564,7 @@
 				92F6CD33F11BF82738AAF81C /* LabReportOCRTests.swift in Sources */,
 				9EDB57CB44E85C5F10064836 /* MacroFormattersTests.swift in Sources */,
 				24FB59FA8518C99125C773FC /* MealTypeDetectionTests.swift in Sources */,
+				935DC53E0F668379205DEC4D /* ModelParityEval.swift in Sources */,
 				6F12940B946478A79A718648 /* MultiTurnContextTests.swift in Sources */,
 				7136ECEEF216184765516FE5 /* NormalizerGoldSetTests.swift in Sources */,
 				2CF22C2420F9E22D2F989C70 /* NotificationServiceTests.swift in Sources */,

--- a/Drift/Services/VoiceTranscriptionPostFixer.swift
+++ b/Drift/Services/VoiceTranscriptionPostFixer.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Post-processes final voice transcripts to repair common health-term misrecognitions
+/// (metformin, creatine, whey, etc.) that Apple's speech recognizer frequently fumbles.
+///
+/// Two rule classes:
+///   1. Unambiguous — apply unconditionally (word-bounded, case-insensitive).
+///   2. Context-guarded — rewrite only when an adjacent disambiguator appears, so we
+///      don't break innocent uses like "I'm creating a meal plan".
+///
+/// Only invoked on FINAL transcripts (not partials), so we can afford regex work
+/// without UX flicker.
+enum VoiceTranscriptionPostFixer {
+
+    /// Apply all rewrites. Idempotent: `fix(fix(x)) == fix(x)`.
+    static func fix(_ text: String) -> String {
+        guard !text.isEmpty else { return text }
+        var working = text
+        for rule in unambiguousRules {
+            working = rule.apply(to: working)
+        }
+        for rule in contextGuardedRules {
+            working = rule.apply(to: working)
+        }
+        return working
+    }
+
+    // MARK: - Rules
+
+    private struct Rule {
+        let pattern: String
+        let replacement: String
+        let options: NSRegularExpression.Options
+
+        init(_ pattern: String, _ replacement: String, options: NSRegularExpression.Options = [.caseInsensitive]) {
+            self.pattern = pattern
+            self.replacement = replacement
+            self.options = options
+        }
+
+        func apply(to text: String) -> String {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else {
+                return text
+            }
+            let range = NSRange(text.startIndex..., in: text)
+            return regex.stringByReplacingMatches(in: text, options: [], range: range, withTemplate: replacement)
+        }
+    }
+
+    /// Unambiguous: these phrasings are almost never legitimate English prose.
+    /// \b = word boundary; (?i) via options for case-insensitive.
+    private static let unambiguousRules: [Rule] = [
+        // Metformin — diabetes med. "Mutter in" / "muttering" / "met foreman" are classic misfires.
+        Rule(#"\bmutter\s+in\b"#, "metformin"),
+        Rule(#"\bmetro\s*form\s*in\b"#, "metformin"),
+        Rule(#"\bmet\s+foreman\b"#, "metformin"),
+        Rule(#"\bmet\s+form\s+in\b"#, "metformin"),
+
+        // Ashwagandha — herbal adaptogen. Apple hears "ash wagon da".
+        Rule(#"\bash\s*wagon\s*da\b"#, "ashwagandha"),
+        Rule(#"\bash\s*wag\s*and\s*a\b"#, "ashwagandha"),
+        Rule(#"\bashwa\s*ganda\b"#, "ashwagandha"),
+
+        // Psyllium (fiber). "Sillium" / "silly um".
+        Rule(#"\bsilly\s*um\b"#, "psyllium"),
+        Rule(#"\bsillium\b"#, "psyllium"),
+
+        // Glucosamine — joints.
+        Rule(#"\bglue\s*cosa\s*mine\b"#, "glucosamine"),
+        Rule(#"\bglucose\s+a\s*mean\b"#, "glucosamine"),
+
+        // Melatonin — sleep.
+        Rule(#"\bmela\s*toning\b"#, "melatonin"),
+        Rule(#"\bmel\s+a\s+tonin\b"#, "melatonin"),
+
+        // Turmeric — "too miric" / "tumor ick".
+        Rule(#"\btumor\s*ick\b"#, "turmeric"),
+        Rule(#"\btoo\s+miric\b"#, "turmeric"),
+
+        // Berberine — glucose.
+        Rule(#"\bbarber\s*een\b"#, "berberine"),
+        Rule(#"\bburberry\b"#, "berberine"),
+
+        // Lion's mane.
+        Rule(#"\blions\s+main\b"#, "lion's mane"),
+        Rule(#"\blion's\s+main\b"#, "lion's mane"),
+
+        // Ozempic / Wegovy / Mounjaro.
+        Rule(#"\bo\s*zen\s*pick\b"#, "ozempic"),
+        Rule(#"\bwe\s+go\s+v\b"#, "wegovy"),
+        Rule(#"\bmount\s*jarrow\b"#, "mounjaro"),
+    ]
+
+    /// Context-guarded: only rewrite when a disambiguator sits adjacent, so we don't
+    /// clobber innocent phrases. Uses lookarounds so we don't consume the guard.
+    /// Lookaheads/behinds are enabled by default in NSRegularExpression.
+    private static let contextGuardedRules: [Rule] = [
+        // Way protein → whey protein (only when "protein" follows within a few tokens).
+        Rule(#"\bway(?=\s+(?:protein|powder|shake|isolate|concentrate))\b"#, "whey"),
+
+        // Creating → creatine (only when supplement-context follows).
+        // Guard on units/forms so "I'm creating a meal plan" stays untouched.
+        Rule(#"\bcreating(?=\s+(?:\d+\s*(?:g|mg|grams)|powder|scoop|monohydrate|mono|supplement))\b"#, "creatine"),
+        Rule(#"(?<=\btook\s)creating\b"#, "creatine"),
+        Rule(#"(?<=\bhad\s)creating\b"#, "creatine"),
+
+        // Case in → casein (only when "protein" follows).
+        Rule(#"\bcase\s+in(?=\s+protein)\b"#, "casein"),
+
+        // Colleague in → collagen (when peptide/powder/supplement follows).
+        Rule(#"\bcolleague\s+in(?=\s+(?:peptide|powder|supplement))\b"#, "collagen"),
+
+        // "Vitamin d three" → "vitamin d3" — only when dosage follows.
+        Rule(#"\bvitamin\s+d\s+three(?=\s+\d)"#, "vitamin d3"),
+
+        // "Omega three" → "omega-3" when supplement context ("fish oil", "capsule", dosage).
+        Rule(#"\bomega\s+three(?=\s+(?:fish|oil|capsule|\d))"#, "omega-3"),
+    ]
+}

--- a/Drift/Views/AI/AIChatView.swift
+++ b/Drift/Views/AI/AIChatView.swift
@@ -102,7 +102,7 @@ struct AIChatView: View {
                                 self.vm.inputText = text
                             },
                             onDone: { finalText in
-                                self.vm.inputText = finalText
+                                self.vm.inputText = VoiceTranscriptionPostFixer.fix(finalText)
                                 self.vm.sendMessage()
                             }
                         )

--- a/DriftLLMEvalMacOS/ChatLatencyBenchmark.swift
+++ b/DriftLLMEvalMacOS/ChatLatencyBenchmark.swift
@@ -1,6 +1,16 @@
 import XCTest
 import Foundation
 
+/// Shared baseline reader for both the 3-run bench and the single-item smoke.
+/// Returns `[query: medianTTFTSeconds]` written by `ChatLatencyBenchmark.saveBaseline`.
+fileprivate func loadLatencyBaseline(at url: URL) -> [String: Double]? {
+    guard let data = try? Data(contentsOf: url),
+          let dict = try? JSONDecoder().decode([String: Double].self, from: data) else {
+        return nil
+    }
+    return dict
+}
+
 /// Measures time-to-first-token (TTFT) for AI chat queries on a warm Gemma 4 model.
 ///
 /// Guards against prompt or context changes that silently regress latency.
@@ -79,9 +89,7 @@ final class ChatLatencyBenchmark: XCTestCase {
     }
 
     private func loadBaseline() -> [String: Double]? {
-        guard let data = try? Data(contentsOf: Self.baselinePath),
-              let dict = try? JSONDecoder().decode([String: Double].self, from: data) else { return nil }
-        return dict
+        loadLatencyBaseline(at: Self.baselinePath)
     }
 
     private func saveBaseline(_ baseline: [String: Double]) {
@@ -168,5 +176,106 @@ final class ChatLatencyBenchmark: XCTestCase {
         print(String(format: "📊 Bloat demo — normal: %.3fs, bloated: %.3fs, ratio: %.2f×", normalMedian, bloatedMedian, ratio))
         XCTAssertGreaterThan(bloatedMedian, normalMedian,
             "Bloated prompt (\(String(format: "%.3f", bloatedMedian))s) should be slower than normal (\(String(format: "%.3f", normalMedian))s)")
+    }
+}
+
+/// Cheap TTFT smoke — runs in the default `DriftLLMEvalMacOS` phase (no opt-in env var).
+///
+/// Guards against catastrophic TTFT regressions on every commit, unlike the 3-run statistical
+/// bench above which stays behind `DRIFT_LATENCY_BENCH=1`. One scenario, one run, two gates:
+///   1. Hard 30s budget — catches hangs or multi-minute cliffs.
+///   2. 1.5× baseline median — catches ~50% regression, loose enough to not flap.
+///
+/// Skips cleanly when the Gemma 4 model isn't present so CI without the model doesn't break.
+/// Baseline is the same `~/drift-state/latency-baseline.json` written by `testTTFT_baseline`.
+final class SingleItemSmokeTest: XCTestCase {
+
+    // MARK: - Constants
+
+    static let regressionMultiplier: Double = 1.5
+    static let hardBudgetSeconds: TimeInterval = 30.0
+    // Use the same query string that exists in ChatLatencyBenchmark.queries, so the baseline
+    // written by the 3-run bench is directly reusable for this smoke's regression gate.
+    static let smokeQuery = "log 2 eggs for breakfast"
+    static let baselinePath = ChatLatencyBenchmark.baselinePath
+    static let gemmaPath = ChatLatencyBenchmark.gemmaPath
+
+    // MARK: - Model (loaded once per class)
+
+    nonisolated(unsafe) static var backend: LlamaCppBackend?
+
+    override class func setUp() {
+        super.setUp()
+        guard FileManager.default.fileExists(atPath: gemmaPath.path) else {
+            print("⏭  SingleItemSmokeTest: Gemma 4 model missing at \(gemmaPath.path) — will skip")
+            return
+        }
+        let b = LlamaCppBackend(modelPath: gemmaPath, threads: 6)
+        try? b.loadSync()
+        guard b.isLoaded else {
+            print("⏭  SingleItemSmokeTest: Gemma 4 load failed — will skip")
+            return
+        }
+        backend = b
+        print("✅ SingleItemSmokeTest: Gemma 4 loaded")
+    }
+
+    // MARK: - Smoke
+
+    func testSingleItemTTFTSmoke() async throws {
+        guard let backend = Self.backend else {
+            throw XCTSkip("Gemma 4 model not available at \(Self.gemmaPath.path)")
+        }
+
+        // One warmup to amortize cold-path costs (mmap page-in, KV-cache init).
+        _ = await backend.respond(to: "hi", systemPrompt: IntentRoutingEval.systemPrompt)
+
+        // Single TTFT measurement.
+        let start = Date()
+        nonisolated(unsafe) var firstTokenTime: TimeInterval = 0
+        nonisolated(unsafe) var received = false
+        _ = await backend.respondStreaming(
+            to: Self.smokeQuery,
+            systemPrompt: IntentRoutingEval.systemPrompt
+        ) { _ in
+            if !received {
+                received = true
+                firstTokenTime = Date().timeIntervalSince(start)
+            }
+        }
+        let ttft = received ? firstTokenTime : Date().timeIntervalSince(start)
+
+        XCTAssertTrue(received, "No tokens received within measurement window")
+
+        // Gate 1: hard 30s budget. Trips on hangs / multi-minute cliffs.
+        XCTAssertLessThanOrEqual(ttft, Self.hardBudgetSeconds,
+            String(format: "TTFT %.2fs exceeds %.0fs hard budget — catastrophic regression",
+                   ttft, Self.hardBudgetSeconds))
+
+        // Gate 2: baseline-relative regression (1.5× median). Only applied when a baseline
+        // exists — otherwise the smoke still validates the pipeline runs end-to-end.
+        if let baseline = loadLatencyBaseline(at: Self.baselinePath),
+           let base = baseline[Self.smokeQuery], base > 0 {
+            let threshold = base * Self.regressionMultiplier
+            print(String(format: "📊 SingleItemSmokeTest: %.3fs (baseline %.3fs, gate %.3fs)",
+                         ttft, base, threshold))
+            XCTAssertLessThanOrEqual(ttft, threshold,
+                String(format: "TTFT %.3fs > %.3fs (%.0f%% of baseline × %.1f)",
+                       ttft, threshold, ttft / base * 100, Self.regressionMultiplier))
+        } else {
+            print(String(format: "📊 SingleItemSmokeTest: %.3fs (no baseline — run DRIFT_LATENCY_BENCH=1 ChatLatencyBenchmark/testTTFT_baseline to establish)", ttft))
+        }
+    }
+
+    // Guard: the smoke must stay cheap — one measurement scenario. If someone adds
+    // more scenarios here by accident, the default test phase balloons. Anyone adding
+    // a real benchmark should extend `ChatLatencyBenchmark` (opt-in) instead.
+    func testSmokeStaysSingleScenario() {
+        // `defaultTestSuite.testCaseCount` reflects the live count of test methods
+        // on this class, so this assertion fails the moment someone adds a third.
+        let count = Self.defaultTestSuite.testCaseCount
+        XCTAssertLessThanOrEqual(count, 2,
+            "SingleItemSmokeTest has \(count) test methods — must remain single-scenario. " +
+            "Add new latency scenarios to ChatLatencyBenchmark (opt-in via DRIFT_LATENCY_BENCH=1) instead.")
     }
 }

--- a/DriftTests/ModelParityEval.swift
+++ b/DriftTests/ModelParityEval.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import Drift
+
+// MARK: - Model Parity Eval (#286)
+//
+// Tier 0/1 queries are handled BEFORE any LLM by `InputNormalizer` + `StaticOverrides`.
+// They MUST be model-agnostic — SmolLM users (Tier small, 6GB devices) and Gemma 4
+// users (Tier large, 8GB+ devices) get identical deterministic behavior on these queries.
+//
+// Three invariants:
+//   1. Coverage   — curated Tier 0/1 queries MUST hit StaticOverrides.match so the LLM
+//                   is never consulted regardless of which model is loaded.
+//   2. Fallthrough — queries that MUST reach the LLM (food/weight/exercise logging,
+//                   info queries) MUST NOT match StaticOverrides; otherwise they'd
+//                   bypass the LLM and lose personalization.
+//   3. Signature  — StaticOverrides.match takes a single String. No model parameter,
+//                   no tier config. Deterministic and model-independent by construction.
+
+// Queries that must short-circuit the LLM on both models.
+// Chosen to avoid runtime DB dependencies (no supplement-taken: needs active supplements).
+private let tier01CoverageQueries: [String] = [
+    // Greetings (StaticOverrides L51)
+    "hi", "hello", "hey",
+    // Thanks (L57)
+    "thanks", "thank you", "got it",
+    // Help (L63)
+    "help", "what can you do",
+    // Barcode (L68)
+    "scan barcode", "barcode",
+    // Navigation (L75 → screenToTab L539)
+    "go to food", "open weight", "show me my dashboard", "open exercise",
+    // Undo (L98) — match() returns a handler; handler is NOT invoked here.
+    "undo", "undo that",
+    // Copy yesterday (L153) — match() returns a handler; handler is NOT invoked.
+    "copy yesterday", "same as yesterday",
+    // Exercise instructions (L251) — resolves against ExerciseDatabase (bundled JSON).
+    "how do i do a deadlift",
+    "how to squat",
+]
+
+// Queries that must reach the LLM pipeline.
+private let fallthroughToLLMQueries: [String] = [
+    // Food logging
+    "log 2 eggs for breakfast",
+    "i had oatmeal with berries",
+    // Weight logging
+    "i weigh 175 lbs",
+    // Exercise logging (workout-set pattern forces fallthrough — L455)
+    "bench press 3x10 at 135",
+    // Info queries — route to AIToolAgent for LLM-presented answers
+    "what did i eat yesterday",
+    "how many calories have i had today",
+]
+
+// MARK: Invariant 1 — Tier 0/1 coverage
+
+@Test @MainActor
+func modelParity_tier01_queriesShortCircuitLLM() {
+    var misses: [String] = []
+    for query in tier01CoverageQueries {
+        let normalized = InputNormalizer.normalize(query)
+        if StaticOverrides.match(normalized) == nil {
+            misses.append(query)
+        }
+    }
+    #expect(misses.isEmpty,
+            "Tier 0/1 queries must hit StaticOverrides so both models behave identically. Misses: \(misses)")
+}
+
+// MARK: Invariant 2 — Fallthrough to LLM
+
+@Test @MainActor
+func modelParity_llmQueriesDoNotShortCircuit() {
+    var unexpectedMatches: [String] = []
+    for query in fallthroughToLLMQueries {
+        let normalized = InputNormalizer.normalize(query)
+        if StaticOverrides.match(normalized) != nil {
+            unexpectedMatches.append(query)
+        }
+    }
+    #expect(unexpectedMatches.isEmpty,
+            "These queries must flow to the LLM, not be short-circuited by StaticOverrides: \(unexpectedMatches)")
+}
+
+// MARK: Invariant 3 — Signature is model-agnostic
+
+// Documents that StaticOverrides.match takes exactly one String — no model, no tier.
+// Any regression that adds a model-branch here would have to change the signature,
+// and this test would fail to compile or fail the determinism check.
+@Test @MainActor
+func modelParity_staticOverridesSignatureIsModelAgnostic() {
+    // Compile-time: the closure below resolves only if the signature is (String) -> StaticResult?.
+    let modelAgnosticMatcher: (String) -> StaticResult? = StaticOverrides.match
+    let first = modelAgnosticMatcher("hi")
+    let second = modelAgnosticMatcher("hi")
+    // Same input yields same match presence. Handler-case results aren't directly
+    // comparable (closures), but response-case results compare by text.
+    #expect((first == nil) == (second == nil),
+            "StaticOverrides.match must be deterministic for the same input")
+    if case let .response(t1) = first, case let .response(t2) = second {
+        #expect(t1 == t2)
+    }
+}

--- a/DriftTests/VoiceTranscriptionPostFixerTests.swift
+++ b/DriftTests/VoiceTranscriptionPostFixerTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+@testable import Drift
+
+final class VoiceTranscriptionPostFixerTests: XCTestCase {
+
+    // MARK: - Unambiguous rewrites
+
+    func testMetforminMutterIn() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("I took mutter in 500mg this morning"),
+            "I took metformin 500mg this morning"
+        )
+    }
+
+    func testMetforminMetForeman() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("met foreman 1000mg"),
+            "metformin 1000mg"
+        )
+    }
+
+    func testAshwagandhaVariants() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("ash wagon da before bed"),
+            "ashwagandha before bed"
+        )
+    }
+
+    func testPsyllium() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("I had silly um husk this morning"),
+            "I had psyllium husk this morning"
+        )
+    }
+
+    func testMelatonin() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("3mg mela toning"),
+            "3mg melatonin"
+        )
+    }
+
+    func testGlucosamine() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("glue cosa mine for my knees"),
+            "glucosamine for my knees"
+        )
+    }
+
+    func testTurmericTumorIck() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("tumor ick capsule"),
+            "turmeric capsule"
+        )
+    }
+
+    func testLionsMane() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("lions main mushroom"),
+            "lion's mane mushroom"
+        )
+    }
+
+    // MARK: - Context-guarded rewrites (positive)
+
+    func testWheyProtein() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("I had way protein after the gym"),
+            "I had whey protein after the gym"
+        )
+    }
+
+    func testWheyShake() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("made a way shake"),
+            "made a whey shake"
+        )
+    }
+
+    func testCreatineWithDose() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("took creating 5g this morning"),
+            "took creatine 5g this morning"
+        )
+    }
+
+    func testCreatineMonohydrate() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("creating monohydrate"),
+            "creatine monohydrate"
+        )
+    }
+
+    func testCasein() {
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("case in protein before bed"),
+            "casein protein before bed"
+        )
+    }
+
+    // MARK: - Context-guarded rewrites (negative guards)
+
+    func testCreatingMealPlanUnchanged() {
+        let input = "I am creating a meal plan for the week"
+        XCTAssertEqual(VoiceTranscriptionPostFixer.fix(input), input)
+    }
+
+    func testCreatingRecipeUnchanged() {
+        let input = "creating a new recipe"
+        XCTAssertEqual(VoiceTranscriptionPostFixer.fix(input), input)
+    }
+
+    func testMutteringSentenceUnchanged() {
+        let input = "the muttering continued throughout the movie"
+        XCTAssertEqual(VoiceTranscriptionPostFixer.fix(input), input)
+    }
+
+    func testWayHomeUnchanged() {
+        let input = "made my way home after dinner"
+        XCTAssertEqual(VoiceTranscriptionPostFixer.fix(input), input)
+    }
+
+    func testCaseInPointUnchanged() {
+        let input = "that is a case in point"
+        XCTAssertEqual(VoiceTranscriptionPostFixer.fix(input), input)
+    }
+
+    // MARK: - Invariants
+
+    func testEmptyStringPassthrough() {
+        XCTAssertEqual(VoiceTranscriptionPostFixer.fix(""), "")
+    }
+
+    func testPlainPhraseUnchanged() {
+        let input = "log 200g chicken breast and rice"
+        XCTAssertEqual(VoiceTranscriptionPostFixer.fix(input), input)
+    }
+
+    func testIdempotenceUnambiguous() {
+        let once = VoiceTranscriptionPostFixer.fix("mutter in and ash wagon da")
+        let twice = VoiceTranscriptionPostFixer.fix(once)
+        XCTAssertEqual(once, twice)
+    }
+
+    func testIdempotenceContextGuarded() {
+        let once = VoiceTranscriptionPostFixer.fix("way protein and creating 5g")
+        let twice = VoiceTranscriptionPostFixer.fix(once)
+        XCTAssertEqual(once, twice)
+    }
+
+    func testCaseInsensitivePreservesRegularText() {
+        // "Mutter In" capitalized should still match — output is always lowercased replacement.
+        XCTAssertEqual(
+            VoiceTranscriptionPostFixer.fix("Mutter In 500mg"),
+            "metformin 500mg"
+        )
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -42,7 +42,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.drift.health
         MARKETING_VERSION: "0.1.0"
-        CURRENT_PROJECT_VERSION: "155"
+        CURRENT_PROJECT_VERSION: "156"
         SWIFT_VERSION: "6.0"
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_FILE: Drift/Info.plist
@@ -74,7 +74,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.drift.health.widget
         MARKETING_VERSION: "0.1.0"
-        CURRENT_PROJECT_VERSION: "155"
+        CURRENT_PROJECT_VERSION: "156"
         SWIFT_VERSION: "6.0"
         INFOPLIST_FILE: DriftWidget/Info.plist
         DEVELOPMENT_TEAM: ZJ5H5XH82A


### PR DESCRIPTION
## Summary
Design doc for Issue #274 — answers *how to curate YouTube videos for exercises* and the muscle-focused visualization ask in the issue body.

- **Track A:** Expand YouTube coverage 33 → ~300 via channel-allowlisted manual curation with a helper CLI. Static URLs in `exercises.json`, opened via `SFSafariViewController`. No API, no quota.
- **Track B (higher leverage):** Ship a vector muscle-highlight card driven by the existing `primaryMuscles` field — one-time mapping table covers all 966 exercises with no per-exercise curation.
- Recommends shipping Track B first, then Track A.

## Test plan
- [ ] Review proposal fit vs. privacy-first / offline-first architecture
- [ ] Confirm `primaryMuscles` taxonomy is complete enough to drive the highlight
- [ ] Pick the body-map SVG source + license (open question #2)
- [ ] Decide who curates the 300 YouTube URLs (open question #1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)