### PR TITLE
fix(hooks): PAUSE/DRAIN enforcement only for autopilot sessions

### DIFF
--- a/.claude/hooks/cycle-counter.sh
+++ b/.claude/hooks/cycle-counter.sh
@@ -4,9 +4,15 @@
 
 set -e
 
-# 1. DRAIN/PAUSE — graceful stop after this commit
+SESSION_TYPE=$(cat "$HOME/drift-state/cache-session-type" 2>/dev/null || echo "junior")
+
+# 1. DRAIN/PAUSE — graceful stop after this commit. ONLY enforced on autopilot
+#    sessions. Ground truth for "is this autopilot" is DRIFT_AUTONOMOUS=1, which
+#    the watchdog exports before launching Claude. The cache-session-type file
+#    is unreliable here because each autopilot spawn overwrites it and human
+#    sessions inherit the stale "senior"/"junior" stamp.
 DRIFT_STATE=$(cat "$HOME/drift-control.txt" 2>/dev/null | tr -d '[:space:]' | tr '[:lower:]' '[:upper:]')
-if [ "$DRIFT_STATE" = "DRAIN" ] || [ "$DRIFT_STATE" = "PAUSE" ]; then
+if [ "${DRIFT_AUTONOMOUS:-}" = "1" ] && { [ "$DRIFT_STATE" = "DRAIN" ] || [ "$DRIFT_STATE" = "PAUSE" ]; }; then
   cat <<ENDJSON
 {
   "hookSpecificOutput": {
@@ -25,7 +31,6 @@ COUNT=$((COUNT + 1))
 echo "$COUNT" > "$COUNTER_FILE"
 
 # 3. Build context injection based on session role
-SESSION_TYPE=$(cat "$HOME/drift-state/cache-session-type" 2>/dev/null || echo "junior")
 CONTEXT=""
 
 # All roles: close bugs with a comment

--- a/.claude/hooks/pause-gate.sh
+++ b/.claude/hooks/pause-gate.sh
@@ -13,6 +13,15 @@ if [[ "$COMMAND" != scripts/sprint-service.sh* && \
     exit 0
 fi
 
+# PAUSE gate only applies to autopilot sessions. The watchdog exports
+# DRIFT_AUTONOMOUS=1 before launching Claude; human-started sessions don't
+# have it. cache-session-type is not used here because it gets overwritten by
+# every autopilot spawn and stays stamped "senior"/"junior"/"planning" during
+# human takeover.
+if [ "${DRIFT_AUTONOMOUS:-}" != "1" ]; then
+    exit 0
+fi
+
 CONTROL="$(cat "$HOME/drift-control.txt" 2>/dev/null || echo RUN)"
 [ "$CONTROL" != "PAUSE" ] && exit 0
 


### PR DESCRIPTION
## Summary
- `cycle-counter.sh` and `pause-gate.sh` now check `DRIFT_AUTONOMOUS=1` (watchdog-set env var) instead of blanket-enforcing PAUSE/DRAIN for every session
- Human takeover sessions (no `DRIFT_AUTONOMOUS=1`) can build, commit, and run tools freely while the watchdog stays parked at PAUSE
- Autopilot PAUSE flow unchanged — still nags and blocks claims as before

## Root cause (what I hit)
After running `echo PAUSE > ~/drift-control.txt` to take over, I couldn't run `xcodebuild` to verify my telemetry changes — the sandbox synthesized the hook-emitted "PAUSE ACTIVE — do not start new work" reminder into a tool-call denial. Previous hooks keyed off `cache-session-type`, but that file gets overwritten by every autopilot spawn, so during takeover it still read `"senior"` from the last autopilot run. `DRIFT_AUTONOMOUS=1` is the ground truth signal (only watchdog-launched sessions have it).

## Test plan
- [ ] Set `echo PAUSE > ~/drift-control.txt`, start a human session, confirm no "PAUSE ACTIVE" reminders on commit
- [ ] Start autopilot (`echo RUN`), confirm PAUSE still blocks autopilot sprint-service claims and still injects the reminder on commit
- [ ] Confirm drift-control test harness still passes: `bash scripts/test-drift-control.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)