### PR TITLE
feat(telemetry): persist raw query + response for multi-turn analysis

### DIFF
--- a/Drift/Database/AppDatabase.swift
+++ b/Drift/Database/AppDatabase.swift
@@ -673,11 +673,12 @@ extension AppDatabase {
         try dbWriter.write { db in
             try db.execute(sql: """
                 INSERT INTO chat_turn
-                (timestamp, query_fingerprint, intent_label, tool_called, outcome, latency_ms, turn_index)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                (timestamp, query_fingerprint, intent_label, tool_called, outcome, latency_ms, turn_index, query_text, response_text)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, arguments: [
                     row.timestamp, row.queryFingerprint, row.intentLabel,
-                    row.toolCalled, row.outcome, row.latencyMs, row.turnIndex
+                    row.toolCalled, row.outcome, row.latencyMs, row.turnIndex,
+                    row.queryText, row.responseText
                 ])
         }
     }
@@ -698,7 +699,7 @@ extension AppDatabase {
     func fetchChatTurns(limit: Int = 5000) throws -> [ChatTurnRow] {
         try dbWriter.read { db in
             let rows = try Row.fetchAll(db, sql: """
-                SELECT timestamp, query_fingerprint, intent_label, tool_called, outcome, latency_ms, turn_index
+                SELECT timestamp, query_fingerprint, intent_label, tool_called, outcome, latency_ms, turn_index, query_text, response_text
                 FROM chat_turn ORDER BY id DESC LIMIT ?
                 """, arguments: [limit])
             return rows.map { r in
@@ -709,7 +710,9 @@ extension AppDatabase {
                     toolCalled: r["tool_called"] as String?,
                     outcome: r["outcome"] as String? ?? "",
                     latencyMs: Int(r["latency_ms"] as Int64? ?? 0),
-                    turnIndex: Int(r["turn_index"] as Int64? ?? 0)
+                    turnIndex: Int(r["turn_index"] as Int64? ?? 0),
+                    queryText: r["query_text"] as String?,
+                    responseText: r["response_text"] as String?
                 )
             }
         }
@@ -730,6 +733,9 @@ extension AppDatabase {
 
 /// Transport struct for chat telemetry rows. Not a GRDB `Record` — intentionally
 /// plain so tests and service code can construct rows without DB setup.
+///
+/// `queryText` and `responseText` are nullable to preserve v32 rows that
+/// pre-date raw-text capture. Written only when opt-in is on.
 struct ChatTurnRow: Equatable, Codable, Sendable {
     var timestamp: String
     var queryFingerprint: String
@@ -738,4 +744,6 @@ struct ChatTurnRow: Equatable, Codable, Sendable {
     var outcome: String
     var latencyMs: Int
     var turnIndex: Int
+    var queryText: String? = nil
+    var responseText: String? = nil
 }

--- a/Drift/Database/Migrations.swift
+++ b/Drift/Database/Migrations.swift
@@ -527,5 +527,16 @@ enum Migrations {
             }
             try db.create(index: "idx_chat_turn_timestamp", on: "chat_turn", columns: ["timestamp"])
         }
+
+        // v33: Store raw query + response text in telemetry so exports can feed
+        // multi-turn failure analysis. Nullable so pre-v33 rows (fingerprint-only)
+        // stay valid. Still on-device only; transmission only via user-initiated
+        // Export JSON.
+        migrator.registerMigration("v33_chat_telemetry_text") { db in
+            try db.alter(table: "chat_turn") { t in
+                t.add(column: "query_text", .text)
+                t.add(column: "response_text", .text)
+            }
+        }
     }
 }

--- a/Drift/Services/AIToolAgent.swift
+++ b/Drift/Services/AIToolAgent.swift
@@ -103,9 +103,12 @@ enum AIToolAgent {
             isLargeModel: isLargeModel, onStep: onStep, onToken: onToken
         )
         // #261 — opt-in gate is inside the service; this call is a no-op by default.
+        // When opt-in is on, `output.text` (the final user-facing response) is
+        // captured alongside the query so transcripts drive multi-turn analysis.
         let latencyMs = Int((CFAbsoluteTimeGetCurrent() - telemetryStart) * 1000)
         ChatTelemetryService.shared.record(
             query: message,
+            response: output.text,
             intent: telemetryIntent(for: output),
             tool: output.toolsCalled.first,
             outcome: telemetryOutcome(for: output),

--- a/Drift/Services/ChatTelemetryService.swift
+++ b/Drift/Services/ChatTelemetryService.swift
@@ -1,14 +1,17 @@
 import Foundation
 import CryptoKit
 
-/// Opt-in, on-device only AI chat telemetry. Records hashed-fingerprint turn
-/// metadata (never raw query text) so we can surface real failure patterns
-/// without breaking the privacy-first promise. #261.
+/// Opt-in, on-device only AI chat telemetry. Records turn metadata plus — when
+/// opt-in is enabled — the raw user query and assistant response text so we
+/// can audit real multi-turn failure transcripts. #261, raw-text capture v33.
 ///
 /// - Disabled by default. All public entry points return early when the
 ///   `Preferences.chatTelemetryEnabled` gate is off.
 /// - Ring buffer: caps `chat_turn` at `ringBufferLimit` rows.
-/// - Network: zero. All data lives in the local SQLite DB.
+/// - Network: zero. Raw text lives in the local SQLite DB and is only
+///   transmitted when the user taps Export JSON + shares it themselves.
+/// - Fingerprint is kept alongside raw text so aggregates that used it
+///   (dedupe-by-query) still work after the schema change.
 final class ChatTelemetryService: @unchecked Sendable {
     static let shared = ChatTelemetryService(db: AppDatabase.shared)
 
@@ -46,8 +49,13 @@ final class ChatTelemetryService: @unchecked Sendable {
 
     /// Fire-and-forget record. Returns immediately; work happens on a utility
     /// queue. No-op when the opt-in gate is off.
+    ///
+    /// `response` is the final assistant-facing text. Stored verbatim alongside
+    /// the query when opt-in is on so exported transcripts can drive multi-turn
+    /// failure analysis. Both raw strings live only in the local DB.
     func record(
         query: String,
+        response: String? = nil,
         intent: IntentLabel?,
         tool: String?,
         outcome: Outcome,
@@ -62,7 +70,9 @@ final class ChatTelemetryService: @unchecked Sendable {
             toolCalled: tool,
             outcome: outcome.rawValue,
             latencyMs: max(0, latencyMs),
-            turnIndex: max(0, turnIndex)
+            turnIndex: max(0, turnIndex),
+            queryText: query,
+            responseText: response
         )
         serialQueue.async { [db] in
             do {

--- a/Drift/Views/Settings/MoreTabView.swift
+++ b/Drift/Views/Settings/MoreTabView.swift
@@ -213,6 +213,7 @@ struct SettingsView: View {
     @State private var telemetryEnabled: Bool = Preferences.chatTelemetryEnabled
     @State private var telemetryCount: Int = 0
     @State private var showingTelemetryDeleteConfirm = false
+    @State private var showingTelemetryEnableConfirm = false
     @State private var telemetryShareURL: URL?
 
     var body: some View {
@@ -396,20 +397,27 @@ struct SettingsView: View {
                             .foregroundStyle(Theme.accent).frame(width: 24)
                         VStack(alignment: .leading, spacing: 2) {
                             Text("AI Chat Telemetry").font(.subheadline.weight(.medium))
-                            Text("Stored on your device only. Helps improve AI chat routing.")
+                            Text("Stored on this device. Nothing is transmitted until you tap Export JSON.")
                                 .font(.caption2).foregroundStyle(.tertiary)
                         }
                         Spacer()
                         Toggle("", isOn: $telemetryEnabled)
                             .labelsHidden().tint(Theme.accent)
                             .onChange(of: telemetryEnabled) { _, on in
-                                Preferences.chatTelemetryEnabled = on
-                                if !on { ChatTelemetryService.shared.deleteAll() }
-                                telemetryCount = ChatTelemetryService.shared.count()
+                                if on {
+                                    // Show the storage disclosure before flipping the pref
+                                    // so the user confirms they understand raw text is kept.
+                                    telemetryEnabled = false
+                                    showingTelemetryEnableConfirm = true
+                                } else {
+                                    Preferences.chatTelemetryEnabled = false
+                                    ChatTelemetryService.shared.deleteAll()
+                                    telemetryCount = ChatTelemetryService.shared.count()
+                                }
                             }
                     }
                     if telemetryEnabled {
-                        Text("Only a short hash of each query — never the raw text — is stored, along with the routed tool and outcome.")
+                        Text("Full query + response text is stored locally, alongside the routed tool and outcome. Use Export JSON to share a transcript with the Drift team to improve multi-turn reliability. Nothing leaves this device until you do.")
                             .font(.caption2).foregroundStyle(.tertiary)
                             .padding(.leading, 36)
 
@@ -457,6 +465,16 @@ struct SettingsView: View {
                     Button("Cancel", role: .cancel) {}
                 } message: {
                     Text("Removes all recorded chat-turn telemetry from this device. User data (weight, food, workouts) is not affected.")
+                }
+                .alert("Store chat transcripts on this device?", isPresented: $showingTelemetryEnableConfirm) {
+                    Button("Turn on") {
+                        Preferences.chatTelemetryEnabled = true
+                        telemetryEnabled = true
+                        telemetryCount = ChatTelemetryService.shared.count()
+                    }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("When on, each chat turn's full query and assistant response will be saved on this device only. Nothing is transmitted. You can Export JSON anytime to share a transcript with the Drift team to improve multi-turn AI reliability, or Delete all to wipe it.")
                 }
 
                 // Photo Log (Beta) — BYOK cloud vision. #224 / #266.

--- a/DriftTests/ChatTelemetryServiceTests.swift
+++ b/DriftTests/ChatTelemetryServiceTests.swift
@@ -90,6 +90,43 @@ private func drain(_ service: ChatTelemetryService) {
     #expect(rows.first?.queryFingerprint.count == ChatTelemetryService.fingerprintHexLength)
 }
 
+@Test func recordPersistsRawQueryAndResponseText() throws {
+    // v33: Raw text is captured when opt-in is on so exported transcripts can
+    // drive multi-turn failure analysis. Fingerprint is still written for
+    // back-compat aggregates.
+    Preferences.chatTelemetryEnabled = true
+    defer { Preferences.chatTelemetryEnabled = false }
+    let db = try makeTestDB()
+    let service = makeService(db: db)
+    service.record(
+        query: "log 2 eggs",
+        response: "Logged 2 eggs (140 kcal).",
+        intent: .toolCall, tool: "log_food",
+        outcome: .success, latencyMs: 120, turnIndex: 3
+    )
+    drain(service)
+    let row = try #require(service.fetchRecent().first)
+    #expect(row.queryText == "log 2 eggs")
+    #expect(row.responseText == "Logged 2 eggs (140 kcal).")
+    #expect(row.queryFingerprint.count == ChatTelemetryService.fingerprintHexLength)
+    #expect(row.turnIndex == 3)
+}
+
+@Test func recordOmitsRawTextWhenOptedOut() throws {
+    // Opt-out path stays airtight: no row written, no raw text captured.
+    Preferences.chatTelemetryEnabled = false
+    let db = try makeTestDB()
+    let service = makeService(db: db)
+    service.record(
+        query: "log 2 eggs",
+        response: "Logged 2 eggs (140 kcal).",
+        intent: .toolCall, tool: "log_food",
+        outcome: .success, latencyMs: 120, turnIndex: 0
+    )
+    Thread.sleep(forTimeInterval: 0.1)
+    #expect(service.count() == 0)
+}
+
 // MARK: - Ring buffer
 
 @Test func ringBufferEvictsOldestBeyondLimit() throws {


### PR DESCRIPTION
## Summary
- New schema v33 adds `query_text` + `response_text` columns to `chat_turn`
- `ChatTelemetryService.record` now captures the full user query and assistant response when opt-in is on — previously only a SHA-256 fingerprint was stored
- Settings toggle sublabel rewritten + confirmation alert on enable explicitly tells the user "saved on this device only; nothing is transmitted until you tap Export JSON"
- Back-compat: pre-v33 rows stay valid (new columns are nullable); `record()` response param defaults to nil so existing callers compile unchanged

## Why
Goal is to improve multi-turn chat reliability by analyzing real failure transcripts. Fingerprint-only telemetry told us "log_food fails 12% of the time" but couldn't tell us *what* users actually typed that tripped the pipeline. Now users can opt-in, accumulate a transcript locally, and Export JSON to share with the Drift team.

Privacy envelope unchanged: disabled by default, zero network, raw text only transmitted when the user explicitly taps Export JSON and shares the file.

## Files changed
- `Drift/Database/Migrations.swift` — v33_chat_telemetry_text
- `Drift/Database/AppDatabase.swift` — ChatTurnRow gains queryText + responseText; INSERT/SELECT updated
- `Drift/Services/ChatTelemetryService.swift` — `record(query:response:...)` signature + docstring
- `Drift/Services/AIToolAgent.swift` — passes `output.text` as response
- `Drift/Views/Settings/MoreTabView.swift` — new sublabel, full description, confirmation alert on enable
- `DriftTests/ChatTelemetryServiceTests.swift` — 2 new tests

## Test plan
- [x] `xcodebuild build` — passes
- [x] `xcodebuild test -only-testing:DriftTests` — 350 tests, 0 failures
- [x] `recordPersistsRawQueryAndResponseText()` — verifies text is stored
- [x] `recordOmitsRawTextWhenOptedOut()` — verifies opt-out is airtight
- [x] Existing `noRawTextIsPersisted` kept as-is — verifies the fingerprint column still doesn't contain raw text (nothing broken by the addition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)