### PR TITLE
feat(photolog): OpenAI + Gemini providers, surface real provider errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ graphify-out/.graphify_uncached.txt
 graphify-out/.graphify_semantic_new.json
 graphify-out/.graphify_transcripts.json
 graphify-out/graph.html
+
+# Local API keys — never commit
+.drift-secrets/
+*.anthropic-key
+/tmp/drift-test-*

--- a/Drift/Services/CloudVision/CloudVisionClient.swift
+++ b/Drift/Services/CloudVision/CloudVisionClient.swift
@@ -13,13 +13,18 @@ protocol CloudVisionClient: Sendable {
 /// Structured errors from cloud vision. Callers (PhotoLogService) map these
 /// to user-facing copy in the review UI. #224.
 enum CloudVisionError: Error, Equatable {
-    case unauthorized        // 401 — key revoked or bad
-    case rateLimited         // 429
-    case timeout             // > 20s or URLSession timeout
-    case offline             // no network reachable
-    case badResponse(Int)    // any other non-2xx
-    case malformedPayload    // couldn't decode PhotoLogResponse from body
-    case transport(String)   // underlying URLSession error, redacted message
+    case unauthorized                          // 401 — key revoked or bad
+    case rateLimited                           // 429
+    case timeout                               // > 20s or URLSession timeout
+    case offline                               // no network reachable
+    /// Non-2xx response where the provider included a structured error body.
+    /// `message` is the human-readable reason pulled from `error.message` —
+    /// surfaces things like "credit balance too low" or "invalid model id"
+    /// that a generic "HTTP 400" would hide.
+    case providerError(status: Int, message: String)
+    case badResponse(Int)                      // non-2xx with no parsable body
+    case malformedPayload                      // couldn't decode PhotoLogResponse from body
+    case transport(String)                     // underlying URLSession error, redacted message
 }
 
 extension CloudVisionError: LocalizedError {
@@ -36,6 +41,8 @@ extension CloudVisionError: LocalizedError {
             return "Provider didn't respond in time. Check your connection and try again."
         case .offline:
             return "No internet. Connect and try again."
+        case .providerError(let status, let message):
+            return "Provider rejected the request (HTTP \(status)): \(message)"
         case .badResponse(let code):
             return "Provider returned HTTP \(code). Try again in a moment."
         case .malformedPayload:
@@ -117,11 +124,37 @@ struct AnthropicVisionClient: CloudVisionClient {
             throw CloudVisionError.badResponse(-1)
         }
         switch http.statusCode {
-        case 200..<300: return data
-        case 401: throw CloudVisionError.unauthorized
-        case 429: throw CloudVisionError.rateLimited
-        default: throw CloudVisionError.badResponse(http.statusCode)
+        case 200..<300:
+            return data
+        case 401:
+            // Keep the dedicated case — its error copy points users at the key field.
+            throw CloudVisionError.unauthorized
+        case 429:
+            throw CloudVisionError.rateLimited
+        default:
+            // Non-2xx with a body Anthropic shaped as `{error:{type, message}}`.
+            // Surface `message` verbatim so the user sees "credit balance too
+            // low" / "invalid model id" instead of a generic "HTTP 400". The
+            // earlier pass threw `.badResponse(400)` on low-credit accounts,
+            // which made the real cause invisible — seen 2026-04-21.
+            if let message = Self.extractErrorMessage(data) {
+                throw CloudVisionError.providerError(status: http.statusCode, message: message)
+            }
+            throw CloudVisionError.badResponse(http.statusCode)
         }
+    }
+
+    /// Pull `error.message` out of an Anthropic error body. Returns nil when
+    /// the body isn't the expected `{error:{message}}` shape so callers can
+    /// fall back to the generic `.badResponse(code)` path.
+    static func extractErrorMessage(_ data: Data) -> String? {
+        guard
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let error = root["error"] as? [String: Any],
+            let message = error["message"] as? String,
+            !message.isEmpty
+        else { return nil }
+        return message
     }
 
     // MARK: Request body
@@ -217,5 +250,307 @@ struct AnthropicVisionClient: CloudVisionClient {
         case .notConnectedToInternet, .networkConnectionLost: return .offline
         default: return .transport("url \(err.code.rawValue)")
         }
+    }
+}
+
+// MARK: - Shared transport helper
+
+/// Same URLError → CloudVisionError mapping used by every provider. Extracted
+/// so provider impls don't each re-declare it.
+fileprivate func mapCloudVisionURLError(_ err: URLError) -> CloudVisionError {
+    switch err.code {
+    case .timedOut: return .timeout
+    case .notConnectedToInternet, .networkConnectionLost: return .offline
+    default: return .transport("url \(err.code.rawValue)")
+    }
+}
+
+// MARK: - OpenAI implementation
+
+/// OpenAI (`gpt-4o-mini`) implementation. Uses Chat Completions with
+/// function calling forced to `food_log` so the model returns structured
+/// JSON instead of prose. Same structured-error surfacing as the Anthropic
+/// client — non-2xx bodies shaped as `{error:{message}}` bubble up as
+/// `.providerError(status:message:)`.
+struct OpenAIVisionClient: CloudVisionClient {
+    static let defaultEndpoint = URL(string: "https://api.openai.com/v1/chat/completions")!
+    /// gpt-4o-mini: vision-capable, ~$0.15/M input. Meal photos are tiny;
+    /// per-call cost is sub-cent. Users can switch via `CloudVisionKey`
+    /// when a dedicated provider override ships.
+    static let defaultModel = "gpt-4o-mini"
+    static let timeoutSeconds: TimeInterval = 20
+
+    let apiKey: String
+    let endpoint: URL
+    let model: String
+    let session: URLSession
+
+    init(
+        apiKey: String,
+        endpoint: URL = OpenAIVisionClient.defaultEndpoint,
+        model: String = OpenAIVisionClient.defaultModel,
+        session: URLSession = .shared
+    ) {
+        self.apiKey = apiKey
+        self.endpoint = endpoint
+        self.model = model
+        self.session = session
+    }
+
+    func analyze(image: Data, prompt: String) async throws -> PhotoLogResponse {
+        let body = try Self.body(model: model, image: image, prompt: prompt)
+        let data = try await send(body: body)
+        return try Self.parseResponse(data)
+    }
+
+    /// Tiny text-only ping. Used by Settings → Test Connection.
+    func ping() async throws {
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 1,
+            "messages": [["role": "user", "content": "ping"]]
+        ]
+        _ = try await send(body: try JSONSerialization.data(withJSONObject: body))
+    }
+
+    private func send(body: Data) async throws -> Data {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = Self.timeoutSeconds
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = body
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch let err as URLError {
+            throw Self.mapURLError(err)
+        } catch {
+            throw CloudVisionError.transport("network failure")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw CloudVisionError.badResponse(-1)
+        }
+        switch http.statusCode {
+        case 200..<300:
+            return data
+        case 401:
+            throw CloudVisionError.unauthorized
+        case 429:
+            throw CloudVisionError.rateLimited
+        default:
+            // OpenAI error shape matches Anthropic's on the `error.message`
+            // field, so the same extractor works for both.
+            if let message = AnthropicVisionClient.extractErrorMessage(data) {
+                throw CloudVisionError.providerError(status: http.statusCode, message: message)
+            }
+            throw CloudVisionError.badResponse(http.statusCode)
+        }
+    }
+
+    // MARK: Request body
+
+    /// Build the Chat Completions body: data-URL image + forced function call.
+    static func body(model: String, image: Data, prompt: String) throws -> Data {
+        let dataURL = "data:image/jpeg;base64,\(image.base64EncodedString())"
+        let payload: [String: Any] = [
+            "model": model,
+            "max_tokens": 1024,
+            "tool_choice": ["type": "function", "function": ["name": "food_log"]],
+            "tools": [[
+                "type": "function",
+                "function": [
+                    "name": "food_log",
+                    "description": "Return structured food identification and macros for the image.",
+                    "parameters": AnthropicVisionClient.foodLogToolSchema
+                ]
+            ]],
+            "messages": [[
+                "role": "user",
+                "content": [
+                    ["type": "image_url", "image_url": ["url": dataURL]],
+                    ["type": "text", "text": prompt]
+                ] as [Any]
+            ]]
+        ]
+        return try JSONSerialization.data(withJSONObject: payload)
+    }
+
+    // MARK: Response parsing
+
+    /// OpenAI returns the function call under
+    /// `choices[0].message.tool_calls[0].function.arguments` as a JSON
+    /// STRING (not an object), so we parse twice: outer response → arguments
+    /// string → PhotoLogResponse.
+    static func parseResponse(_ data: Data) throws -> PhotoLogResponse {
+        guard
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let choices = root["choices"] as? [[String: Any]],
+            let first = choices.first,
+            let message = first["message"] as? [String: Any],
+            let toolCalls = message["tool_calls"] as? [[String: Any]],
+            let function = toolCalls.first?["function"] as? [String: Any],
+            let argumentsString = function["arguments"] as? String,
+            let argsData = argumentsString.data(using: .utf8),
+            let parsed = try? JSONDecoder().decode(PhotoLogResponse.self, from: argsData)
+        else {
+            throw CloudVisionError.malformedPayload
+        }
+        return parsed
+    }
+
+    private static func mapURLError(_ err: URLError) -> CloudVisionError {
+        mapCloudVisionURLError(err)
+    }
+}
+
+// MARK: - Google Gemini implementation
+
+/// Google Gemini implementation (AI Studio / Generative Language API). Uses
+/// function calling with `toolConfig.functionCallingConfig.mode = "ANY"` so
+/// the model is forced to emit a `food_log` call. Key goes in the URL as
+/// `?key=` per the Gemini API — no Authorization header.
+struct GeminiVisionClient: CloudVisionClient {
+    /// Default model. `gemini-2.5-flash` is the current vision-capable GA
+    /// flash model on v1beta. `gemini-1.5-flash` was deprecated off the API;
+    /// we saw a live 404 for it on 2026-04-21 before switching.
+    static let defaultModel = "gemini-2.5-flash"
+    static let defaultEndpointBase = "https://generativelanguage.googleapis.com/v1beta/models"
+    static let timeoutSeconds: TimeInterval = 20
+
+    let apiKey: String
+    let endpointBase: String
+    let model: String
+    let session: URLSession
+
+    init(
+        apiKey: String,
+        endpointBase: String = GeminiVisionClient.defaultEndpointBase,
+        model: String = GeminiVisionClient.defaultModel,
+        session: URLSession = .shared
+    ) {
+        self.apiKey = apiKey
+        self.endpointBase = endpointBase
+        self.model = model
+        self.session = session
+    }
+
+    /// Compose the `generateContent` URL with the key in the query string.
+    /// The key never appears in headers or logs outside this getter.
+    var endpoint: URL {
+        URL(string: "\(endpointBase)/\(model):generateContent?key=\(apiKey)")!
+    }
+
+    func analyze(image: Data, prompt: String) async throws -> PhotoLogResponse {
+        let body = try Self.body(image: image, prompt: prompt)
+        let data = try await send(body: body)
+        return try Self.parseResponse(data)
+    }
+
+    /// Tiny text ping used by Settings → Test Connection. 8 tokens of
+    /// headroom is enough to survive Gemini 2.5's hidden "thinking" budget
+    /// before the response arrives — too low and we get HTTP 200 with an
+    /// empty text part, which the user reads as "broken".
+    func ping() async throws {
+        let body: [String: Any] = [
+            "contents": [["parts": [["text": "ping"]]]],
+            "generationConfig": ["maxOutputTokens": 8]
+        ]
+        _ = try await send(body: try JSONSerialization.data(withJSONObject: body))
+    }
+
+    private func send(body: Data) async throws -> Data {
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = Self.timeoutSeconds
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = body
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch let err as URLError {
+            throw mapCloudVisionURLError(err)
+        } catch {
+            throw CloudVisionError.transport("network failure")
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw CloudVisionError.badResponse(-1)
+        }
+        switch http.statusCode {
+        case 200..<300:
+            return data
+        case 401, 403:
+            // Gemini uses 403 for invalid API key; treat as unauthorized so
+            // UI copy points users at the key field.
+            throw CloudVisionError.unauthorized
+        case 429:
+            throw CloudVisionError.rateLimited
+        default:
+            if let message = AnthropicVisionClient.extractErrorMessage(data) {
+                throw CloudVisionError.providerError(status: http.statusCode, message: message)
+            }
+            throw CloudVisionError.badResponse(http.statusCode)
+        }
+    }
+
+    // MARK: Request body
+
+    /// Gemini `generateContent` body: inline image + forced function call.
+    /// `toolConfig.functionCallingConfig.mode = "ANY"` with an explicit
+    /// `allowedFunctionNames` is the Gemini equivalent of Anthropic's
+    /// `tool_choice` — the model has to invoke `food_log`.
+    static func body(image: Data, prompt: String) throws -> Data {
+        let payload: [String: Any] = [
+            "contents": [[
+                "parts": [
+                    ["inline_data": ["mime_type": "image/jpeg", "data": image.base64EncodedString()]],
+                    ["text": prompt]
+                ] as [Any]
+            ]],
+            "tools": [[
+                "functionDeclarations": [[
+                    "name": "food_log",
+                    "description": "Return structured food identification and macros for the image.",
+                    "parameters": AnthropicVisionClient.foodLogToolSchema
+                ]]
+            ]],
+            "toolConfig": [
+                "functionCallingConfig": [
+                    "mode": "ANY",
+                    "allowedFunctionNames": ["food_log"]
+                ]
+            ]
+        ]
+        return try JSONSerialization.data(withJSONObject: payload)
+    }
+
+    // MARK: Response parsing
+
+    /// Gemini returns the function call under
+    /// `candidates[0].content.parts[].functionCall.args` — `args` is already
+    /// a parsed JSON object (unlike OpenAI's JSON-string `arguments`), so we
+    /// serialize it back to bytes and decode as `PhotoLogResponse`.
+    static func parseResponse(_ data: Data) throws -> PhotoLogResponse {
+        guard
+            let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let candidates = root["candidates"] as? [[String: Any]],
+            let firstCandidate = candidates.first,
+            let content = firstCandidate["content"] as? [String: Any],
+            let parts = content["parts"] as? [[String: Any]]
+        else {
+            throw CloudVisionError.malformedPayload
+        }
+        let functionCall = parts.compactMap { $0["functionCall"] as? [String: Any] }.first
+        guard
+            let call = functionCall,
+            let args = call["args"] as? [String: Any],
+            let argsData = try? JSONSerialization.data(withJSONObject: args),
+            let parsed = try? JSONDecoder().decode(PhotoLogResponse.self, from: argsData)
+        else {
+            throw CloudVisionError.malformedPayload
+        }
+        return parsed
     }
 }

--- a/Drift/Services/CloudVision/CloudVisionKey.swift
+++ b/Drift/Services/CloudVision/CloudVisionKey.swift
@@ -7,11 +7,13 @@ import LocalAuthentication
 enum CloudVisionProvider: String, CaseIterable, Codable, Sendable {
     case anthropic
     case openai
+    case gemini
 
     var displayName: String {
         switch self {
         case .anthropic: return "Anthropic (Claude)"
-        case .openai: return "OpenAI (GPT-4o)"
+        case .openai:    return "OpenAI (GPT-4o)"
+        case .gemini:    return "Google (Gemini 2.5)"
         }
     }
 }

--- a/Drift/Services/PhotoLogTool.swift
+++ b/Drift/Services/PhotoLogTool.swift
@@ -95,12 +95,14 @@ enum PhotoLogTool {
             return errorOutput("Photo analysis timed out. Check your connection and try again.")
         } catch CloudVisionError.offline, PhotoLogService.Error.offline {
             return errorOutput("Couldn't reach the provider. Check your connection and try again.")
+        } catch let CloudVisionError.providerError(status, message) {
+            // Surface the real reason (credit balance, invalid key, etc.) so
+            // users know whether to add credit or re-enter the key.
+            return errorOutput("Provider rejected the request (HTTP \(status)): \(message)")
         } catch CloudVisionError.malformedPayload {
             return errorOutput("Provider returned an unreadable response. Try a clearer photo.")
         } catch PhotoLogService.Error.encodingFailed {
             return errorOutput("Couldn't prepare that image. Try a different photo.")
-        } catch OpenAINotImplemented.flag {
-            return errorOutput("OpenAI support is coming soon. Switch to Anthropic to use Photo Log today.")
         } catch CloudVisionKey.StorageError.notFound {
             return errorOutput("No key saved. Add one in Settings → Photo Log (Beta).")
         } catch {
@@ -110,10 +112,6 @@ enum PhotoLogTool {
 
     // MARK: - Default service wiring
 
-    /// Sentinel thrown when the selected provider has no client yet (OpenAI).
-    /// Using a throw keeps the `do/catch` in `run` flat.
-    private enum OpenAINotImplemented: Error { case flag }
-
     private static func buildDefaultService() async throws -> PhotoLogService {
         let provider = Preferences.photoLogProvider
         guard let key = try await CloudVisionKey.get(for: provider) else {
@@ -121,10 +119,9 @@ enum PhotoLogTool {
         }
         let client: CloudVisionClient
         switch provider {
-        case .anthropic:
-            client = AnthropicVisionClient(apiKey: key)
-        case .openai:
-            throw OpenAINotImplemented.flag
+        case .anthropic: client = AnthropicVisionClient(apiKey: key)
+        case .openai:    client = OpenAIVisionClient(apiKey: key)
+        case .gemini:    client = GeminiVisionClient(apiKey: key)
         }
         return PhotoLogService(client: client)
     }

--- a/Drift/Views/PhotoLog/PhotoLogFlowView.swift
+++ b/Drift/Views/PhotoLog/PhotoLogFlowView.swift
@@ -237,10 +237,9 @@ enum PhotoLogFlowService {
         }
         let client: CloudVisionClient
         switch provider {
-        case .anthropic:
-            client = AnthropicVisionClient(apiKey: key)
-        case .openai:
-            throw CloudVisionError.malformedPayload  // OpenAI not wired yet
+        case .anthropic: client = AnthropicVisionClient(apiKey: key)
+        case .openai:    client = OpenAIVisionClient(apiKey: key)
+        case .gemini:    client = GeminiVisionClient(apiKey: key)
         }
         let service = PhotoLogService(client: client)
         return try await service.analyze(image: image, prompt: PhotoLogTool.defaultPrompt)

--- a/Drift/Views/Settings/PhotoLogBetaSettingsView.swift
+++ b/Drift/Views/Settings/PhotoLogBetaSettingsView.swift
@@ -197,11 +197,14 @@ struct PhotoLogBetaSettingsView: View {
             }
             switch provider {
             case .anthropic:
-                let client = AnthropicVisionClient(apiKey: key)
-                try await client.ping()
+                try await AnthropicVisionClient(apiKey: key).ping()
                 status = .success("Connection OK.")
             case .openai:
-                status = .error("OpenAI client not implemented yet.")
+                try await OpenAIVisionClient(apiKey: key).ping()
+                status = .success("Connection OK.")
+            case .gemini:
+                try await GeminiVisionClient(apiKey: key).ping()
+                status = .success("Connection OK.")
             }
         } catch let error as CloudVisionError {
             // LocalizedError conformance gives actionable copy per case.

--- a/DriftTests/CloudVisionClientTests.swift
+++ b/DriftTests/CloudVisionClientTests.swift
@@ -263,3 +263,261 @@ private func stubbedSession() -> URLSession {
     #expect(parsed.items[0].confidence == .low)
     #expect(parsed.overallConfidence == .low)
 }
+
+// MARK: - providerError surfacing
+
+@Test func anthropic400WithErrorMessageMapsToProviderError() async throws {
+    // Replicates the 2026-04-21 "credit balance too low" response that was
+    // previously being hidden behind a generic .badResponse(400).
+    StubURLProtocol.reset()
+    let body = #"{"type":"error","error":{"type":"invalid_request_error","message":"Your credit balance is too low to access the Anthropic API."}}"#
+    StubURLProtocol.responder = { _ in (400, Data(body.utf8)) }
+    let client = AnthropicVisionClient(apiKey: "good", session: stubbedSession())
+    await #expect(throws: CloudVisionError.providerError(status: 400, message: "Your credit balance is too low to access the Anthropic API.")) {
+        try await client.analyze(image: Data([0xff]), prompt: "x")
+    }
+}
+
+@Test func errorMessageExtractorReturnsNilOnNonStandardShape() {
+    // Falls back to .badResponse(code) when the body isn't the expected
+    // {error:{message}} shape.
+    #expect(AnthropicVisionClient.extractErrorMessage(Data("not json".utf8)) == nil)
+    #expect(AnthropicVisionClient.extractErrorMessage(Data(#"{"foo":"bar"}"#.utf8)) == nil)
+    #expect(AnthropicVisionClient.extractErrorMessage(Data(#"{"error":"just a string"}"#.utf8)) == nil)
+    #expect(AnthropicVisionClient.extractErrorMessage(Data(#"{"error":{"type":"x"}}"#.utf8)) == nil)
+    #expect(AnthropicVisionClient.extractErrorMessage(Data(#"{"error":{"message":""}}"#.utf8)) == nil)
+    #expect(AnthropicVisionClient.extractErrorMessage(Data(#"{"error":{"message":"real"}}"#.utf8)) == "real")
+}
+
+// MARK: - OpenAI
+
+@Test func openaiSuccessParsesToolCallArguments() async throws {
+    // OpenAI returns arguments as a JSON *string* under
+    // choices[0].message.tool_calls[0].function.arguments.
+    StubURLProtocol.reset()
+    StubURLProtocol.responder = { _ in
+        let argumentsJSON = #"{\"items\":[{\"name\":\"caesar salad\",\"grams\":210,\"calories\":350,\"protein_g\":12,\"carbs_g\":20,\"fat_g\":25,\"confidence\":\"medium\"}],\"overall_confidence\":\"medium\",\"notes\":\"Assumed dressing included.\"}"#
+        let body = """
+        {
+          "id": "chatcmpl-fake",
+          "choices": [{
+            "index": 0,
+            "message": {
+              "role": "assistant",
+              "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                  "name": "food_log",
+                  "arguments": "\(argumentsJSON)"
+                }
+              }]
+            },
+            "finish_reason": "tool_calls"
+          }]
+        }
+        """
+        return (200, Data(body.utf8))
+    }
+    let client = OpenAIVisionClient(apiKey: "sk-fake", session: stubbedSession())
+    let resp = try await client.analyze(image: Data([0xff, 0xd8]), prompt: "what is this?")
+    #expect(resp.items.count == 1)
+    #expect(resp.items[0].name == "caesar salad")
+    #expect(resp.items[0].calories == 350)
+    #expect(resp.overallConfidence == .medium)
+    #expect(resp.notes == "Assumed dressing included.")
+}
+
+@Test func openaiRequestHasBearerAuthAndForcedFunctionCall() async throws {
+    StubURLProtocol.reset()
+    StubURLProtocol.responder = { _ in
+        let body = #"{"choices":[{"message":{"tool_calls":[{"function":{"name":"food_log","arguments":"{\"items\":[],\"overall_confidence\":\"low\"}"}}]}}]}"#
+        return (200, Data(body.utf8))
+    }
+    let client = OpenAIVisionClient(apiKey: "sk-secret", session: stubbedSession())
+    _ = try? await client.analyze(image: Data([0xff]), prompt: "hi")
+    let req = StubURLProtocol.lastRequest
+    #expect(req?.value(forHTTPHeaderField: "Authorization") == "Bearer sk-secret")
+    #expect(req?.value(forHTTPHeaderField: "content-type") == "application/json")
+    #expect(req?.httpMethod == "POST")
+}
+
+@Test func openai401MapsToUnauthorized() async throws {
+    StubURLProtocol.reset()
+    StubURLProtocol.responder = { _ in (401, Data(#"{"error":{"message":"Incorrect API key"}}"#.utf8)) }
+    let client = OpenAIVisionClient(apiKey: "bad", session: stubbedSession())
+    await #expect(throws: CloudVisionError.unauthorized) {
+        try await client.analyze(image: Data([0xff]), prompt: "x")
+    }
+}
+
+@Test func openai400WithUnsupportedImageMapsToProviderError() async throws {
+    StubURLProtocol.reset()
+    let body = #"{"error":{"type":"invalid_request_error","code":"invalid_image","message":"You uploaded an unsupported image."}}"#
+    StubURLProtocol.responder = { _ in (400, Data(body.utf8)) }
+    let client = OpenAIVisionClient(apiKey: "good", session: stubbedSession())
+    await #expect(throws: CloudVisionError.providerError(status: 400, message: "You uploaded an unsupported image.")) {
+        try await client.analyze(image: Data([0xff]), prompt: "x")
+    }
+}
+
+@Test func openaiMissingToolCallsMapsToMalformedPayload() async throws {
+    StubURLProtocol.reset()
+    // Plain-text response (no tool_calls) — model declined to call the
+    // function despite tool_choice. Surface as malformed so the user sees a
+    // clear error instead of a silent empty result.
+    StubURLProtocol.responder = { _ in
+        let body = #"{"choices":[{"message":{"role":"assistant","content":"I can't identify that image."}}]}"#
+        return (200, Data(body.utf8))
+    }
+    let client = OpenAIVisionClient(apiKey: "good", session: stubbedSession())
+    await #expect(throws: CloudVisionError.malformedPayload) {
+        try await client.analyze(image: Data([0xff]), prompt: "x")
+    }
+}
+
+@Test func openaiBodyShapesImageAsDataURL() throws {
+    let data = try OpenAIVisionClient.body(
+        model: "gpt-4o-mini",
+        image: Data([0x01, 0x02, 0x03]),
+        prompt: "log this"
+    )
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    #expect(json?["model"] as? String == "gpt-4o-mini")
+    // tool_choice shape
+    let toolChoice = json?["tool_choice"] as? [String: Any]
+    #expect(toolChoice?["type"] as? String == "function")
+    #expect((toolChoice?["function"] as? [String: Any])?["name"] as? String == "food_log")
+    // Image sent as data: URL
+    let messages = json?["messages"] as? [[String: Any]]
+    let content = messages?.first?["content"] as? [[String: Any]]
+    let imageBlock = content?.first { ($0["type"] as? String) == "image_url" }
+    let url = (imageBlock?["image_url"] as? [String: Any])?["url"] as? String
+    #expect(url?.hasPrefix("data:image/jpeg;base64,") == true)
+    #expect(url?.contains(Data([0x01, 0x02, 0x03]).base64EncodedString()) == true)
+}
+
+// MARK: - Gemini
+
+@Test func geminiSuccessParsesFunctionCallArgs() async throws {
+    // Gemini returns args as an already-parsed JSON object under
+    // candidates[0].content.parts[].functionCall.args.
+    StubURLProtocol.reset()
+    StubURLProtocol.responder = { _ in
+        let body = """
+        {
+          "candidates": [{
+            "content": {
+              "parts": [{
+                "functionCall": {
+                  "name": "food_log",
+                  "args": {
+                    "items": [{
+                      "name": "masala dosa",
+                      "grams": 220,
+                      "calories": 420,
+                      "protein_g": 9,
+                      "carbs_g": 58,
+                      "fat_g": 18,
+                      "confidence": "medium"
+                    }],
+                    "overall_confidence": "medium",
+                    "notes": "Potato filling assumed."
+                  }
+                }
+              }]
+            }
+          }]
+        }
+        """
+        return (200, Data(body.utf8))
+    }
+    let client = GeminiVisionClient(apiKey: "gkey", session: stubbedSession())
+    let resp = try await client.analyze(image: Data([0xff, 0xd8]), prompt: "what's on the plate?")
+    #expect(resp.items.count == 1)
+    #expect(resp.items[0].name == "masala dosa")
+    #expect(resp.items[0].calories == 420)
+    #expect(resp.overallConfidence == .medium)
+    #expect(resp.notes == "Potato filling assumed.")
+}
+
+@Test func geminiRequestKeyGoesInQueryString() async throws {
+    StubURLProtocol.reset()
+    StubURLProtocol.responder = { _ in
+        let body = #"{"candidates":[{"content":{"parts":[{"functionCall":{"name":"food_log","args":{"items":[],"overall_confidence":"low"}}}]}}]}"#
+        return (200, Data(body.utf8))
+    }
+    let client = GeminiVisionClient(apiKey: "gk-secret", session: stubbedSession())
+    _ = try? await client.analyze(image: Data([0xff]), prompt: "hi")
+    let req = StubURLProtocol.lastRequest
+    // Key goes in query param `?key=`, NOT a header.
+    #expect(req?.url?.absoluteString.contains("key=gk-secret") == true)
+    #expect(req?.value(forHTTPHeaderField: "Authorization") == nil)
+    #expect(req?.value(forHTTPHeaderField: "x-api-key") == nil)
+    #expect(req?.httpMethod == "POST")
+}
+
+@Test func gemini401Or403MapsToUnauthorized() async throws {
+    // Gemini signals a bad key with 403, not 401 — the client normalizes.
+    StubURLProtocol.reset()
+    StubURLProtocol.responder = { _ in
+        (403, Data(#"{"error":{"code":403,"message":"API key not valid","status":"PERMISSION_DENIED"}}"#.utf8))
+    }
+    let client = GeminiVisionClient(apiKey: "bad", session: stubbedSession())
+    await #expect(throws: CloudVisionError.unauthorized) {
+        try await client.analyze(image: Data([0xff]), prompt: "x")
+    }
+}
+
+@Test func gemini404WithModelNotFoundMapsToProviderError() async throws {
+    // Exactly the response seen for `gemini-1.5-flash` on 2026-04-21 —
+    // users switching models via a future override need the real reason.
+    StubURLProtocol.reset()
+    let body = #"{"error":{"code":404,"message":"models/gemini-1.5-flash is not found for API version v1beta","status":"NOT_FOUND"}}"#
+    StubURLProtocol.responder = { _ in (404, Data(body.utf8)) }
+    let client = GeminiVisionClient(apiKey: "good", session: stubbedSession())
+    await #expect(throws: CloudVisionError.providerError(
+        status: 404,
+        message: "models/gemini-1.5-flash is not found for API version v1beta"
+    )) {
+        try await client.analyze(image: Data([0xff]), prompt: "x")
+    }
+}
+
+@Test func geminiMissingFunctionCallMapsToMalformedPayload() async throws {
+    // Gemini sometimes returns `content.parts[].text` only (ignored tool
+    // config) or no `functionCall` entry at all — treat as malformed so the
+    // user sees a clear error instead of a silent empty result.
+    StubURLProtocol.reset()
+    StubURLProtocol.responder = { _ in
+        let body = #"{"candidates":[{"content":{"parts":[{"text":"I can't identify that image."}]}}]}"#
+        return (200, Data(body.utf8))
+    }
+    let client = GeminiVisionClient(apiKey: "good", session: stubbedSession())
+    await #expect(throws: CloudVisionError.malformedPayload) {
+        try await client.analyze(image: Data([0xff]), prompt: "x")
+    }
+}
+
+@Test func geminiBodyForcesFoodLogFunctionCall() throws {
+    let data = try GeminiVisionClient.body(
+        image: Data([0x01, 0x02, 0x03]),
+        prompt: "log this"
+    )
+    let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    // Function declaration
+    let tools = json?["tools"] as? [[String: Any]]
+    let decls = tools?.first?["functionDeclarations"] as? [[String: Any]]
+    #expect(decls?.first?["name"] as? String == "food_log")
+    // Forced call mode
+    let toolConfig = json?["toolConfig"] as? [String: Any]
+    let fcc = toolConfig?["functionCallingConfig"] as? [String: Any]
+    #expect(fcc?["mode"] as? String == "ANY")
+    #expect(fcc?["allowedFunctionNames"] as? [String] == ["food_log"])
+    // Inline image
+    let contents = json?["contents"] as? [[String: Any]]
+    let parts = contents?.first?["parts"] as? [[String: Any]]
+    let inline = parts?.first(where: { $0["inline_data"] != nil })?["inline_data"] as? [String: Any]
+    #expect(inline?["mime_type"] as? String == "image/jpeg")
+    #expect(inline?["data"] as? String == Data([0x01, 0x02, 0x03]).base64EncodedString())
+}


### PR DESCRIPTION
## Summary
Photo Log was failing silently. Verified live today: Anthropic key is valid; account is out of credit. The server returns HTTP 400 with `{error:{message:"Your credit balance is too low..."}}` — previously buried as "Provider returned HTTP 400. Try again in a moment."

## What shipped
- `CloudVisionError.providerError(status:message:)` — surfaces the real reason
- `OpenAIVisionClient` (gpt-4o-mini, function-call forced to `food_log`)
- `GeminiVisionClient` (gemini-2.5-flash, `toolConfig.mode=ANY` forcing `food_log`, key in URL)
- `CloudVisionProvider.gemini` added — Settings picker auto-gets it via `.allCases`
- PhotoLogTool / PhotoLogFlowView / PhotoLogBetaSettingsView wired for all three
- 8 new tests: error surfacing, OpenAI round-trip, Gemini round-trip + edge cases

## Live probes
- Anthropic: valid key, no credit → `providerError(400): "Your credit balance is too low..."` (as designed)
- OpenAI: 200 OK (gpt-4o-mini)
- Gemini: 200 OK (gemini-2.5-flash). 1.5-flash is off v1beta — defaulted to 2.5

## Test plan
- [x] `xcodebuild build` passes
- [x] `xcodebuild test -only-testing:DriftTests` — 1988 tests, 0 failures