### PR TITLE
feat(ai): weight_trend_prediction — when will I reach my goal weight?

### DIFF
--- a/Drift.xcodeproj/project.pbxproj
+++ b/Drift.xcodeproj/project.pbxproj
@@ -222,10 +222,12 @@
 		C4412538AE3E1E269685CB2A /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99C89E28D8FBE125273FB677 /* Log.swift */; };
 		C4714D3A48A3B723EE018B44 /* ComposedFoodParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7B91A7052D8347083F577A /* ComposedFoodParserTests.swift */; };
 		C4B459EA365A74DF9ED1330A /* SavedFood.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9BADD02A9760A82C60DE4E /* SavedFood.swift */; };
+		C61D8AC77173D8CD82FE2513 /* WeightTrendPredictionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30EBE5E51C7C37890E868629 /* WeightTrendPredictionTests.swift */; };
 		C6533AEBED5F6D1F5387F98A /* RobustnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647116F9E4F78CE702CB870C /* RobustnessTests.swift */; };
 		C7666848928C7210A8CE6BD6 /* PromptOptimizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBF19C358E700091486400DD /* PromptOptimizer.swift */; };
 		C78684F2133F07AAAC383EDB /* GoalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3258B6E91169170587AAB02B /* GoalView.swift */; };
 		C7DCB089BF4DCF1916C4B0E5 /* GoalView+Profile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B8EAC57A3A10193855A81F /* GoalView+Profile.swift */; };
+		C91A4CC8AC42557332AB117B /* WeightTrendPredictionTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D19CF3C4B4B51F64BE89E1 /* WeightTrendPredictionTool.swift */; };
 		CA3F2052B0B3E9E56D7AF064 /* WeeklySummaryRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550B90AE65B6BF4C31B62382 /* WeeklySummaryRoutingTests.swift */; };
 		CBACE89C978AA0377081831E /* WeightServiceAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED47C488D5D052F183327F8 /* WeightServiceAPITests.swift */; };
 		CC5B581BFDDE48FB00D4E442 /* StaticOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F915E1ECAEF188959934E07 /* StaticOverrides.swift */; };
@@ -407,6 +409,7 @@
 		2E52DF869EA41A78F57F6CC8 /* IntentClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentClassifier.swift; sourceTree = "<group>"; };
 		30537026EE533EE546180AB3 /* AIModelManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIModelManagerTests.swift; sourceTree = "<group>"; };
 		3053C86565C8B26D3B16A0A2 /* AutoResearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoResearchTests.swift; sourceTree = "<group>"; };
+		30EBE5E51C7C37890E868629 /* WeightTrendPredictionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTrendPredictionTests.swift; sourceTree = "<group>"; };
 		3120313481E2B0C45C1B573A /* top-500-foods.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "top-500-foods.txt"; sourceTree = "<group>"; };
 		3258B6E91169170587AAB02B /* GoalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalView.swift; sourceTree = "<group>"; };
 		32AC5A6130E7655FFC74502F /* DatabaseEdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseEdgeCaseTests.swift; sourceTree = "<group>"; };
@@ -431,6 +434,7 @@
 		4200A9F331B35DB8ACB881A3 /* DomainExtractorEval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainExtractorEval.swift; sourceTree = "<group>"; };
 		42A6CAF4720F61DC0C9BD2E7 /* FoodSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodSearchView.swift; sourceTree = "<group>"; };
 		42CC554F9454FF0FC8A31F56 /* BiomarkerKnowledgeBase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiomarkerKnowledgeBase.swift; sourceTree = "<group>"; };
+		43D19CF3C4B4B51F64BE89E1 /* WeightTrendPredictionTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeightTrendPredictionTool.swift; sourceTree = "<group>"; };
 		46E22593ED4EAC860EFBF887 /* WorkoutPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutPersistenceTests.swift; sourceTree = "<group>"; };
 		47334FA11098E0172ED4A19A /* EdgeCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeCaseTests.swift; sourceTree = "<group>"; };
 		483437CB4AFE28505FCFE44A /* AIChatView+MessageHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AIChatView+MessageHandling.swift"; sourceTree = "<group>"; };
@@ -811,6 +815,7 @@
 				550B90AE65B6BF4C31B62382 /* WeeklySummaryRoutingTests.swift */,
 				BED47C488D5D052F183327F8 /* WeightServiceAPITests.swift */,
 				3F51E9EC49412B4F96068D35 /* WeightTrendCalculatorTests.swift */,
+				30EBE5E51C7C37890E868629 /* WeightTrendPredictionTests.swift */,
 				FA0DCFCDAFF06DBAD3CA13DB /* WidgetDataTests.swift */,
 				46E22593ED4EAC860EFBF887 /* WorkoutPersistenceTests.swift */,
 				1A884AC137C46CE932FEE1C9 /* WorkoutTests.swift */,
@@ -930,6 +935,7 @@
 			isa = PBXGroup;
 			children = (
 				5102ED20EA22B7AD30719309 /* CrossDomainInsightTool.swift */,
+				43D19CF3C4B4B51F64BE89E1 /* WeightTrendPredictionTool.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -1523,6 +1529,7 @@
 				4595A34B3A929843D9FBA307 /* WeightServiceAPI.swift in Sources */,
 				0884D534B3ADDE47643801F8 /* WeightTabView.swift in Sources */,
 				ADFD099AC0AEB4154AF6063B /* WeightTrendCalculator.swift in Sources */,
+				C91A4CC8AC42557332AB117B /* WeightTrendPredictionTool.swift in Sources */,
 				67E6DD4C4837E4F4EB971CB2 /* WeightTrendService.swift in Sources */,
 				6A4AC25199199579681FCAD4 /* WeightViewModel.swift in Sources */,
 				3A1B5CCC6960BB3FE2AD5B2C /* WidgetDataProvider.swift in Sources */,
@@ -1628,6 +1635,7 @@
 				CA3F2052B0B3E9E56D7AF064 /* WeeklySummaryRoutingTests.swift in Sources */,
 				CBACE89C978AA0377081831E /* WeightServiceAPITests.swift in Sources */,
 				DF025680665178535364944C /* WeightTrendCalculatorTests.swift in Sources */,
+				C61D8AC77173D8CD82FE2513 /* WeightTrendPredictionTests.swift in Sources */,
 				B8CAE0734166CD113EE590E8 /* WidgetDataTests.swift in Sources */,
 				2789D96230755D58B91B3175 /* WorkoutPersistenceTests.swift in Sources */,
 				92B596C732C7784167EC8CDE /* WorkoutTests.swift in Sources */,

--- a/Drift/Services/IntentClassifier.swift
+++ b/Drift/Services/IntentClassifier.swift
@@ -24,7 +24,7 @@ enum IntentClassifier {
 
     static var systemPrompt: String = """
     Health app. Reply JSON tool call or short text. Fix typos, word numbers, slang.
-    Tools: log_food(name,servings?,calories?,protein?,carbs?,fat?) food_info(query) log_weight(value,unit?) weight_info(query?) start_workout(name?) log_activity(name,duration?) exercise_info(query?) sleep_recovery(period?) mark_supplement(name) supplements() set_goal(target,unit?) delete_food(entry_id?,name?) edit_meal(entry_id?,meal_period?,action,target_food?,new_value?) body_comp() glucose() biomarkers() navigate_to(screen) cross_domain_insight(metric_a,metric_b,window_days?)
+    Tools: log_food(name,servings?,calories?,protein?,carbs?,fat?) food_info(query) log_weight(value,unit?) weight_info(query?) start_workout(name?) log_activity(name,duration?) exercise_info(query?) sleep_recovery(period?) mark_supplement(name) supplements() set_goal(target,unit?) delete_food(entry_id?,name?) edit_meal(entry_id?,meal_period?,action,target_food?,new_value?) body_comp() glucose() biomarkers() navigate_to(screen) cross_domain_insight(metric_a,metric_b,window_days?) weight_trend_prediction()
     When <recent_entries> is shown and user refers to a row (by ordinal, calories, meal, or "the one I just logged"), pass its id as entry_id. Otherwise use name/target_food.
     Rules: never invent health data — call a tool. "calories in X"→food_info (not log_food). log_food when user ate/had OR said log/add/track/record with a named food. Bare "log lunch/breakfast/dinner" (no food)→ask what they had. "search/find X in my logs"→food_info, not log_food. summary/intake/macros→food_info. weight trend→weight_info. body fat/lean mass/DEXA→body_comp. blood sugar/glucose spike→glucose. lab results/biomarkers/cholesterol→biomarkers. HRV→sleep_recovery. "go to X"/"open X"→navigate_to. supplements() for any supplement status question (never text). mark_supplement when user took/had one.
     Ask vs guess: if user names a concrete food/supplement/exercise/weight/screen, act. Only ask when query has no object (bare "log", "track", "add") or two tools fit equally.
@@ -62,6 +62,9 @@ enum IntentClassifier {
     If <recent_entries> lists "42|lunch|rice|180cal|3m": "delete the rice I just logged"→{"tool":"delete_food","entry_id":"42"}
     If <recent_entries> shows two rows and user says "delete the first one"→use the id of the earlier row.
     If <recent_entries> has a 500cal row at id 7: "edit the 500 cal one to 2 servings"→{"tool":"edit_meal","entry_id":"7","action":"update_quantity","new_value":"2"}
+    "when will I reach my goal weight"→{"tool":"weight_trend_prediction"}
+    "how long until I hit 75kg"→{"tool":"weight_trend_prediction"}
+    "when will I reach 160 lbs"→{"tool":"weight_trend_prediction"}
     "did I lose weight on workout days"→{"tool":"cross_domain_insight","metric_a":"weight","metric_b":"workout_volume"}
     "glucose vs carbs last week"→{"tool":"cross_domain_insight","metric_a":"glucose_avg","metric_b":"carbs","window_days":"7"}
     "protein on lifting days vs rest"→{"tool":"cross_domain_insight","metric_a":"protein","metric_b":"workout_volume"}

--- a/Drift/Services/IntentThresholds.swift
+++ b/Drift/Services/IntentThresholds.swift
@@ -18,7 +18,7 @@ enum IntentDomain: String, Sendable, CaseIterable {
     case exercise
     /// mark_supplement, supplements
     case supplements
-    /// body_comp, glucose, biomarkers, cross_domain_insight — read-only
+    /// body_comp, glucose, biomarkers, cross_domain_insight, weight_trend_prediction — read-only
     /// data queries, never ambiguous
     case data
     /// navigate_to — screen name is context-sensitive ("sleep tab" vs "sleep data")
@@ -40,7 +40,7 @@ enum IntentDomain: String, Sendable, CaseIterable {
             return .exercise
         case "mark_supplement", "supplements":
             return .supplements
-        case "body_comp", "glucose", "biomarkers", "cross_domain_insight":
+        case "body_comp", "glucose", "biomarkers", "cross_domain_insight", "weight_trend_prediction":
             return .data
         case "navigate_to":
             return .meta

--- a/Drift/Services/ToolRegistration.swift
+++ b/Drift/Services/ToolRegistration.swift
@@ -721,6 +721,10 @@ enum ToolRegistration {
         // metrics over a window. Read-only. #317.
         CrossDomainInsightTool.syncRegistration(registry: r)
 
+        // Weight trend prediction — "when will I reach my goal weight?"
+        // OLS regression on last 30 days → projected date + R² confidence. #402.
+        WeightTrendPredictionTool.syncRegistration(registry: r)
+
         // MARK: - Conditional Tools
         // Photo Log is gated on the beta flag AND a stored cloud-vision key.
         // Keeping this last so the gated call is the single conditional hop.

--- a/Drift/Services/Tools/WeightTrendPredictionTool.swift
+++ b/Drift/Services/Tools/WeightTrendPredictionTool.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+@MainActor
+enum WeightTrendPredictionTool {
+
+    nonisolated static let toolName = "weight_trend_prediction"
+
+    private nonisolated static let minEntriesRequired = 7
+    private nonisolated static let flatSlopeThresholdKgPerDay = 0.01 / 7.0
+    private nonisolated static let wrongDirectionThresholdKgPerDay = 0.005
+    private nonisolated static let maxProjectionDays = 1825
+
+    // MARK: - Registration
+
+    static func syncRegistration(registry: ToolRegistry = .shared) {
+        registry.register(schema)
+    }
+
+    static var schema: ToolSchema {
+        ToolSchema(
+            id: "insights.weight_trend_prediction",
+            name: toolName,
+            service: "insights",
+            description: "User asks when they'll reach their goal weight or how long it will take. Returns projected date, weekly rate, and confidence based on current trend.",
+            parameters: [],
+            handler: { _ in .text(run()) }
+        )
+    }
+
+    // MARK: - Entry point
+
+    static func run() -> String {
+        guard let goal = WeightGoal.load() else {
+            return "Set a goal weight first — try 'set my goal to 75 kg' and I'll project when you'll get there."
+        }
+
+        let entries = WeightServiceAPI.getHistory(days: 30)
+        guard entries.count >= minEntriesRequired else {
+            return "Need at least \(minEntriesRequired) days of weight data to predict — you have \(entries.count). Keep logging daily and ask again."
+        }
+
+        guard let reg = linearRegression(entries: entries) else {
+            return "Couldn't compute a trend. Make sure weights are logged on different dates."
+        }
+
+        let u = Preferences.weightUnit
+        let currentKg = WeightTrendService.shared.latestWeightKg ?? entries.sorted { $0.date > $1.date }.first?.weightKg ?? 70
+        let targetKg = goal.targetWeightKg
+        let slopePerDay = reg.slopePerDay
+        let slopePerWeek = slopePerDay * 7
+        let remaining = targetKg - currentKg
+        let isLosing = targetKg < currentKg
+
+        let isFlat = abs(slopePerDay) < flatSlopeThresholdKgPerDay
+        let wrongDirection = (isLosing && slopePerDay > wrongDirectionThresholdKgPerDay) ||
+                             (!isLosing && slopePerDay < -wrongDirectionThresholdKgPerDay)
+
+        let targetDisplay = String(format: "%.1f", u.convert(fromKg: targetKg))
+        let rateDisplay = String(format: "%.2f", abs(u.convert(fromKg: slopePerWeek)))
+        let currentDisplay = String(format: "%.1f", u.convert(fromKg: currentKg))
+
+        if isFlat {
+            return "Your weight has been stable at ~\(currentDisplay) \(u.displayName). At this rate you won't reach \(targetDisplay) \(u.displayName). Adjust your diet or training to build momentum."
+        }
+
+        if wrongDirection {
+            let dir = isLosing ? "gaining" : "losing"
+            return "You're currently \(dir) \(rateDisplay) \(u.displayName)/week — moving away from your goal of \(targetDisplay) \(u.displayName). Refocus on nutrition and training to reverse the trend."
+        }
+
+        let daysToGoal = remaining / slopePerDay
+        if daysToGoal > Double(maxProjectionDays) {
+            return "At \(rateDisplay) \(u.displayName)/week, reaching \(targetDisplay) \(u.displayName) would take over 5 years. Consider adjusting your goal timeline or increasing your weekly rate."
+        }
+
+        guard daysToGoal > 0 else {
+            return "You've already reached or passed your goal of \(targetDisplay) \(u.displayName). Consider setting a new goal."
+        }
+
+        let projectedDate = Calendar.current.date(byAdding: .day, value: Int(daysToGoal.rounded()), to: Date()) ?? Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM d, yyyy"
+        let dateStr = formatter.string(from: projectedDate)
+        let weeksAway = max(1, Int((daysToGoal / 7).rounded()))
+        let r2Pct = Int(reg.r2 * 100)
+
+        return "At your current rate of \(rateDisplay) \(u.displayName)/week, you'll reach \(targetDisplay) \(u.displayName) around \(dateStr) (~\(weeksAway) weeks). Trend confidence: \(r2Label(reg.r2)) (R²=\(r2Pct)%)."
+    }
+
+    // MARK: - OLS linear regression
+
+    struct RegressionResult: Sendable {
+        let slopePerDay: Double
+        let interceptKg: Double
+        let r2: Double
+    }
+
+    nonisolated static func linearRegression(entries: [WeightEntry]) -> RegressionResult? {
+        guard entries.count >= 2 else { return nil }
+        let fmt = DateFormatters.dateOnly
+        let sorted = entries.sorted { $0.date < $1.date }
+        guard let firstDate = fmt.date(from: sorted.first!.date) else { return nil }
+
+        let pairs: [(x: Double, y: Double)] = sorted.compactMap { e in
+            guard let d = fmt.date(from: e.date) else { return nil }
+            let dayIndex = Calendar.current.dateComponents([.day], from: firstDate, to: d).day ?? 0
+            return (Double(dayIndex), e.weightKg)
+        }
+        guard pairs.count >= 2 else { return nil }
+
+        let n = Double(pairs.count)
+        let sumX = pairs.map(\.x).reduce(0, +)
+        let sumY = pairs.map(\.y).reduce(0, +)
+        let sumXY = pairs.map { $0.x * $0.y }.reduce(0, +)
+        let sumX2 = pairs.map { $0.x * $0.x }.reduce(0, +)
+        let denom = n * sumX2 - sumX * sumX
+        guard abs(denom) > 0 else { return nil }
+
+        let slope = (n * sumXY - sumX * sumY) / denom
+        let intercept = (sumY - slope * sumX) / n
+        let meanY = sumY / n
+        let ssRes = pairs.map { pow($0.y - (slope * $0.x + intercept), 2) }.reduce(0, +)
+        let ssTot = pairs.map { pow($0.y - meanY, 2) }.reduce(0, +)
+        let r2 = ssTot > 0 ? max(0, 1 - ssRes / ssTot) : 1.0
+
+        return RegressionResult(slopePerDay: slope, interceptKg: intercept, r2: r2)
+    }
+
+    nonisolated static func r2Label(_ r2: Double) -> String {
+        if r2 >= 0.7 { return "high" }
+        if r2 >= 0.4 { return "moderate" }
+        return "low"
+    }
+}

--- a/DriftTests/WeightTrendPredictionTests.swift
+++ b/DriftTests/WeightTrendPredictionTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import Drift
+
+private func makeEntries(startDate: String, weightKgByDay: [Double]) -> [WeightEntry] {
+    let fmt = DateFormatters.dateOnly
+    guard let base = fmt.date(from: startDate) else { return [] }
+    return weightKgByDay.enumerated().compactMap { (i, kg) in
+        guard let d = Calendar.current.date(byAdding: .day, value: i, to: base) else { return nil }
+        return WeightEntry(date: fmt.string(from: d), weightKg: kg, source: "manual")
+    }
+}
+
+// MARK: - Regression math
+
+@Test func weightTrend_steadyLoss_negativeSlopeHighR2() {
+    let entries = makeEntries(startDate: "2026-03-01", weightKgByDay: [80, 79.9, 79.8, 79.7, 79.6, 79.5, 79.4, 79.3, 79.2, 79.1])
+    let result = WeightTrendPredictionTool.linearRegression(entries: entries)
+    #expect(result != nil)
+    #expect((result?.slopePerDay ?? 0) < 0, "losing weight → negative slope")
+    #expect((result?.r2 ?? 0) > 0.95, "steady loss → high R²")
+}
+
+@Test func weightTrend_steadyGain_positiveSlopeHighR2() {
+    let entries = makeEntries(startDate: "2026-03-01", weightKgByDay: [70, 70.1, 70.2, 70.3, 70.4, 70.5, 70.6, 70.7])
+    let result = WeightTrendPredictionTool.linearRegression(entries: entries)
+    #expect(result != nil)
+    #expect((result?.slopePerDay ?? 0) > 0, "gaining weight → positive slope")
+    #expect((result?.r2 ?? 0) > 0.95, "steady gain → high R²")
+}
+
+@Test func weightTrend_flatData_nearZeroSlope() {
+    let entries = makeEntries(startDate: "2026-03-01", weightKgByDay: [75, 75, 75, 75, 75, 75, 75, 75])
+    let result = WeightTrendPredictionTool.linearRegression(entries: entries)
+    #expect(result != nil)
+    #expect(abs(result!.slopePerDay) < 0.001, "flat weight → slope ≈ 0")
+}
+
+@Test func weightTrend_tooFewEntries_returnsNil() {
+    let one = makeEntries(startDate: "2026-03-01", weightKgByDay: [80])
+    #expect(WeightTrendPredictionTool.linearRegression(entries: one) == nil)
+    #expect(WeightTrendPredictionTool.linearRegression(entries: []) == nil)
+}
+
+@Test func weightTrend_noisyData_r2LessThanSteady() {
+    let entries = makeEntries(startDate: "2026-03-01", weightKgByDay: [80, 79, 81, 78, 82, 77, 80, 79, 78, 77])
+    let result = WeightTrendPredictionTool.linearRegression(entries: entries)
+    let steady = makeEntries(startDate: "2026-03-01", weightKgByDay: [80, 79.9, 79.8, 79.7, 79.6, 79.5, 79.4, 79.3, 79.2, 79.1])
+    let steadyResult = WeightTrendPredictionTool.linearRegression(entries: steady)
+    #expect((result?.r2 ?? 1) < (steadyResult?.r2 ?? 0), "noisy series has lower R² than steady series")
+}
+
+@Test func weightTrend_r2Label_correctBuckets() {
+    #expect(WeightTrendPredictionTool.r2Label(0.8) == "high")
+    #expect(WeightTrendPredictionTool.r2Label(0.7) == "high")
+    #expect(WeightTrendPredictionTool.r2Label(0.5) == "moderate")
+    #expect(WeightTrendPredictionTool.r2Label(0.4) == "moderate")
+    #expect(WeightTrendPredictionTool.r2Label(0.3) == "low")
+    #expect(WeightTrendPredictionTool.r2Label(0.0) == "low")
+}
+
+@Test func weightTrend_slopeMatchesExpectedRate() {
+    // 10 days, losing exactly 0.1 kg/day → slope should be -0.1 kg/day
+    let entries = makeEntries(startDate: "2026-03-01", weightKgByDay: [80, 79.9, 79.8, 79.7, 79.6, 79.5, 79.4, 79.3, 79.2, 79.1])
+    let result = WeightTrendPredictionTool.linearRegression(entries: entries)
+    #expect(result != nil)
+    #expect(abs((result?.slopePerDay ?? 0) - (-0.1)) < 0.001, "slope should be -0.1 kg/day")
+}


### PR DESCRIPTION
## Summary
- New `WeightTrendPredictionTool` analytical tool answers "when will I reach my goal weight?" using OLS linear regression on the last 30 days of weight entries
- Returns projected goal date, weekly rate, and R² confidence rating
- Full edge case handling: no goal set, insufficient data (<7 entries), flat trend, wrong direction, >5-year projection

## Files changed
- `Drift/Services/Tools/WeightTrendPredictionTool.swift` — new tool (OLS regression, `@MainActor enum`, `nonisolated` pure math)
- `Drift/Services/ToolRegistration.swift` — registers the tool
- `Drift/Services/IntentClassifier.swift` — adds tool to LLM prompt + 3 routing examples
- `Drift/Services/IntentThresholds.swift` — maps tool to `.data` domain (always proceed, no clarification)
- `DriftTests/WeightTrendPredictionTests.swift` — 7 unit tests covering regression math and edge cases

## Test plan
- [x] All 2057 unit tests pass
- [x] `weightTrend_steadyLoss_negativeSlopeHighR2` — slope < 0, R² > 0.95
- [x] `weightTrend_steadyGain_positiveSlopeHighR2` — slope > 0, R² > 0.95
- [x] `weightTrend_flatData_nearZeroSlope` — slope ≈ 0
- [x] `weightTrend_tooFewEntries_returnsNil` — nil for < 2 entries
- [x] `weightTrend_noisyData_r2LessThanSteady` — noisy < steady R²
- [x] `weightTrend_r2Label_correctBuckets` — high/moderate/low thresholds
- [x] `weightTrend_slopeMatchesExpectedRate` — exactly -0.1 kg/day for known series

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)