### PR TITLE
report: exec briefing 2026-05-14

### DIFF
--- a/Docs/reports/exec-2026-05-14.md
+++ b/Docs/reports/exec-2026-05-14.md
@@ -1,0 +1,46 @@
+# Drift Daily Briefing — 2026-05-14
+
+## Headline
+FoodLogIntent unified extractor lands (design-666 QW1) — one typed Apple Foundation Models call now replaces the ~340-LOC regex pipeline for food-log messages on iOS/macOS 26+, with the regex path preserved verbatim behind a kill-switch.
+
+## Product Snapshot
+Drift is an AI-first health tracker — users type what they ate or did, AI handles logging, tracking, and insights. On-device, no cloud. Currently in closed beta on TestFlight.
+
+| | |
+|---|---|
+| Beta Build | 246 (publishing now; build 245 shipped 2026-05-13) |
+| Test Suite | ~1219 iOS DriftTests + ~1484 macOS DriftCoreTests (+44 today), LLM eval ~160 cases |
+| AI Capabilities | 37 registered tools (24 core + 13 insight) |
+| Food Database | 5,420 foods (Indian-first curated, 6,000 ceiling enforced) |
+
+## What Shipped This Period
+- **Unified food-log intent extraction (design-666 QW1, #743)** — `FMFoodLogIntent` typed schema with `@Generable` annotations covers eight quantity-unit families (counts, weights, volumes, portions, plates/bowls, slices, multipliers, meal hints) in a single FM call. Replaces a four-stage regex pipeline (parseFoodIntent + parseMultiFoodIntent + extractAmount + matchIngredient) that wins on coverage (no-verb messages, plate/bowl units) and correctness (portion-word stumbles like "half a banana"). 44-test Tier-0 suite includes bounds, prompt anchors, bridge mapping, and a 40-row gold set with regex-baseline tagging so the FM-vs-regex delta is measurable. Kill-switch defaults ON; flag-off path proven byte-identical to the regex over the full gold set.
+- **V6 design reference checked in (#782)** — local Drift v6 HTML/JSX prototype + V3/V4 screenshots mirrored into `Docs/design-ref/v6/` so SwiftUI translation work can reference the source without leaving the repo. 296 KB total; not used at runtime.
+- **FoundationModelsBackend wired (PR A of Task 1)** — `.foundationModels` LLM backend type registered, providing the seam the QW1 work above uses.
+- **First-launch backup nudge + migration version fix** — gentle onboarding nudge to enable iCloud backup at app start; migrations version field corrected so older devices don't re-run a finished migration.
+
+## What's Working Well
+- The design-666 QW-series is delivering on its promise: QW1 (food-log) now joins QW2 (composite food) and QW3 (workout entry) — three regex-chain replacements in one design doc, all with kill-switches, all with regex-baseline gold sets that measure the FM win. The pattern is repeatable.
+- DriftCore test suite stays fast — 1484 tests in ~5.4s warm (was 1366 at the 2026-05-12 briefing). Adding 44 new tests added <0.1s. Tier discipline is holding.
+- Sprint queue health is good: 9 SENIOR open, 0 P0, 31 junior. The bug-free state has held for multiple cycles — the WIP recovery flow and orphan-design self-heal keep adding insurance.
+
+## Risks & Blockers
+- **Daily exec briefing hook still fires repeatedly** — flagged in the 2026-05-11 and 2026-05-12 briefings, still unfixed. Every Bash call post-commit re-injects the briefing instructions. This makes mid-session work noisy and risks the model deferring real work to re-write the same briefing. Worth a small infra ticket to gate the hook on planning-mode or a per-session sentinel.
+- **No iOS-side test coverage for the new async FM food-intent path yet** — the Tier-0 suite proves the regex-equivalent path and the typed bridge, but the live FM-on path only ships under iOS 26+ runtime and is currently exercised in `DriftLLMEvalMacOS` only. The Tier-3 gold set extension is the next deliverable for this work.
+- **iCloud backup is wired but provisioning-profile-blocked** (carryover from 2026-05-12). Beta users still don't have backup until entitlements re-enable.
+
+## Focus for Next Period
+1. **Tier-3 LLM-backed gold set for FoodLogIntentExtractor** — the 40-row gold set already exists with regex baselines tagged; the Tier-3 extension is mechanical and gives us live FM-vs-regex numbers that the QW2/QW3 work has but QW1 currently lacks.
+2. **Drain the next senior task (#708 iCloud backup E2E dogfood)** — needs human/friend-tester action, but the engineering side of the verification harness can be prepped (wipe-and-restore script, fixture device).
+3. **Resolve the exec-briefing hook conflict** — now flagged 4 days in a row. Either gate on planning-mode or add a session-scoped `report-skipped-today` marker. Until this lands every briefing also notes the same blocker.
+
+## Cost
+| | |
+|---|---|
+| Model | Opus 4.7 |
+| Sessions today | 1 (current — post-QW1 land) |
+| Est. cost today | n/a — token-usage.sh not run this cycle |
+| Cost/cycle | n/a |
+
+---
+Comment on any line for strategic feedback. @ashish-sadh

--- a/DriftCore/Sources/DriftCore/AI/FoundationModels/FoodLogIntentExtractor.swift
+++ b/DriftCore/Sources/DriftCore/AI/FoundationModels/FoodLogIntentExtractor.swift
@@ -1,0 +1,224 @@
+import Foundation
+#if canImport(FoundationModels)
+import FoundationModels
+#endif
+
+// MARK: - Public output type (available on all OS versions)
+
+/// One food-logging intent extracted by the FM pipeline. Mirrors the
+/// `@Generable FMFoodLogIntentSchema` below. Replaces the per-stage regex
+/// chain (parseFoodIntent + parseMultiFoodIntent + extractAmount +
+/// matchIngredient — ~340 LOC) with a single typed call. Indian-food bar
+/// applies: prompt must handle bare-juxtaposition compounds and
+/// regional units (plates, bowls) the regex doesn't cover.
+public struct FMFoodLogIntent: Sendable, Equatable {
+    public enum Unit: String, Sendable {
+        case grams, ounces, milliliters, cups, tablespoons, teaspoons,
+             pieces, slices, plates, bowls, servings
+    }
+
+    public enum MealType: String, Sendable {
+        case breakfast, lunch, dinner, snack
+    }
+
+    public struct Item: Sendable, Equatable {
+        public let foodName: String
+        public let quantity: Double
+        public let unit: Unit
+
+        public init(foodName: String, quantity: Double, unit: Unit) {
+            self.foodName = foodName
+            self.quantity = quantity
+            self.unit = unit
+        }
+    }
+
+    public let foodName: String
+    public let quantity: Double
+    public let unit: Unit
+    public let mealType: MealType?
+    public let additionalItems: [Item]
+
+    public init(
+        foodName: String,
+        quantity: Double,
+        unit: Unit,
+        mealType: MealType? = nil,
+        additionalItems: [Item] = []
+    ) {
+        self.foodName = foodName
+        self.quantity = quantity
+        self.unit = unit
+        self.mealType = mealType
+        self.additionalItems = additionalItems
+    }
+}
+
+public enum FMFoodLogIntentExtractorError: Error, Sendable {
+    case unavailable
+    case sessionFailed(String)
+    /// FM produced empty `foodName` — the message wasn't a food log
+    /// ("show me my weight chart", "log workout"). Caller falls through to
+    /// the regex parser which has its own non-food sentinel handling.
+    case notFoodLog
+    /// FM returned a numeric out of plausible-meal range. Caller falls back
+    /// to regex; downstream macro sanity checks would have caught it anyway.
+    case bounded(field: String, value: Double)
+}
+
+// MARK: - Bounds (design-666 QW1 sanity post-extraction)
+
+public enum FoodLogIntentBounds {
+    /// 0.01 = a tiny dash (1/100 tsp). 100 = a 100-piece bag of grapes / 100g.
+    /// Anything outside is a hallucination — bail to regex.
+    public static let quantityRange: ClosedRange<Double> = 0.01...100
+    /// Realistic ceiling for "I had X, Y, Z, ..." style messages. Above this is
+    /// almost always the FM splitting one dish into ingredient words.
+    public static let maxAdditionalItems: Int = 9
+
+    public enum Violation: Equatable, Sendable {
+        case notFoodLog
+        case quantityOutOfRange(Double)
+        case tooManyAdditionals(Int)
+    }
+
+    public static func violation(in intent: FMFoodLogIntent) -> Violation? {
+        if intent.foodName.trimmingCharacters(in: .whitespaces).isEmpty {
+            return .notFoodLog
+        }
+        if !quantityRange.contains(intent.quantity) {
+            return .quantityOutOfRange(intent.quantity)
+        }
+        if intent.additionalItems.count > maxAdditionalItems {
+            return .tooManyAdditionals(intent.additionalItems.count)
+        }
+        return nil
+    }
+}
+
+// MARK: - Extractor
+
+public enum FoodLogIntentExtractor {
+
+    /// Extract a typed food-log intent from a free-text user message.
+    /// Throws `.unavailable` on iOS<26 / macOS<26 or when FoundationModels is
+    /// not linked; throws `.notFoodLog` when the model returns an empty
+    /// foodName (non-food query); throws `.bounded` on out-of-range numerics.
+    /// All throw cases tell the caller to fall back to the regex path.
+    public static func extract(text: String) async throws -> FMFoodLogIntent {
+#if canImport(FoundationModels)
+        if #available(macOS 26, iOS 26, *) {
+            let prompt = buildPrompt(for: text)
+            do {
+                let session = LanguageModelSession()
+                let response = try await session.respond(to: prompt, generating: FMFoodLogIntentSchema.self)
+                let primaryUnit = FMFoodLogIntent.Unit(rawValue: response.content.unit.lowercased()) ?? .servings
+                let mealType: FMFoodLogIntent.MealType? = response.content.mealType
+                    .flatMap { FMFoodLogIntent.MealType(rawValue: $0.lowercased()) }
+                let intent = FMFoodLogIntent(
+                    foodName: response.content.foodName,
+                    quantity: response.content.quantity,
+                    unit: primaryUnit,
+                    mealType: mealType,
+                    additionalItems: response.content.additionalItems.map {
+                        FMFoodLogIntent.Item(
+                            foodName: $0.foodName,
+                            quantity: $0.quantity,
+                            unit: FMFoodLogIntent.Unit(rawValue: $0.unit.lowercased()) ?? .servings
+                        )
+                    }
+                )
+                if let v = FoodLogIntentBounds.violation(in: intent) {
+                    switch v {
+                    case .notFoodLog:
+                        throw FMFoodLogIntentExtractorError.notFoodLog
+                    case .quantityOutOfRange(let q):
+                        throw FMFoodLogIntentExtractorError.bounded(field: "quantity", value: q)
+                    case .tooManyAdditionals(let n):
+                        throw FMFoodLogIntentExtractorError.bounded(field: "additionalItems", value: Double(n))
+                    }
+                }
+                return intent
+            } catch let err as FMFoodLogIntentExtractorError {
+                throw err
+            } catch {
+                throw FMFoodLogIntentExtractorError.sessionFailed("\(error)")
+            }
+        }
+#endif
+        throw FMFoodLogIntentExtractorError.unavailable
+    }
+
+    /// Prompt sent to the foundation model. Covers the eight families the
+    /// regex chain juggles today across ~340 LOC: counts, weights, volumes,
+    /// portions, fractions, multipliers, meal hints, and the non-food
+    /// sentinel ("show me my weight chart" must return empty foodName so
+    /// downstream falls through to the right tool instead of synthesizing
+    /// a bogus food log).
+    public static func buildPrompt(for text: String) -> String {
+        """
+        Parse the user's message into a structured food-logging intent.
+
+        Quantity + unit families:
+        - Counts: "2 eggs", "3 bananas" → quantity=2, unit=pieces (whole-piece foods)
+        - Weights: "200g paneer", "8 oz chicken" → quantity=200, unit=grams (convert ounces×28.35 to grams ONLY if you must; otherwise return the user's literal unit and let downstream convert)
+        - Volumes: "1 cup oats", "2 tbsp honey", "1 tsp ghee", "200ml milk" → keep cups/tablespoons/teaspoons/milliliters verbatim
+        - Portions: "half a banana", "a quarter cup oats", "1/3 avocado" → quantity=0.5/0.25/0.333, unit matches what the user said (pieces / cups)
+        - Plates / bowls / servings: "a plate of biryani", "a bowl of dal", "1 serving rice" → unit=plates/bowls/servings
+        - Slices: "2 slices bread" → unit=slices
+        - Multipliers: "double the rice" → quantity=2, unit=servings; "triple the eggs" → quantity=3, unit=pieces; "2x chicken" → quantity=2, unit=servings
+        - No quantity: "log eggs", "ate paneer" → quantity=1, unit=servings (user didn't specify — downstream defaults to 1 serving)
+
+        Meal hint: if the user said "for breakfast/lunch/dinner/snack", set mealType. Otherwise leave nil.
+
+        Compound foods that LOOK like multi-food but are ONE dish — keep as a single foodName, no additionalItems:
+        - "mac and cheese", "bread and butter", "salt and pepper", "rice and beans",
+          "peanut butter and jelly", "fish and chips", "ham and cheese"
+
+        Multi-food messages ("chicken and rice", "eggs, toast, and coffee") — split into primary + additionalItems. The primary is the first food mentioned. Each additional item carries its own quantity + unit.
+
+        Non-food / data-request messages — return EMPTY foodName (downstream routes elsewhere):
+        - "show me my weight chart" → foodName="", quantity=1, unit=servings
+        - "log workout", "exercise", "weight", "sleep", "summary", "supplement" → foodName=""
+        - "what did I eat yesterday" → foodName=""
+
+        Food name rules:
+        - Use singular canonical form: "egg" not "eggs", "banana" not "bananas".
+        - Preserve the user's specific dish name verbatim (e.g. "chicken biryani" stays one phrase, not split into chicken + biryani).
+        - Do NOT invent foods the user didn't mention.
+
+        Text:
+
+        \(text)
+        """
+    }
+}
+
+// MARK: - Generable schema (compiled only on macOS 26+ / iOS 26+)
+
+#if canImport(FoundationModels)
+@available(macOS 26, iOS 26, *)
+@Generable
+struct FMFoodLogIntentSchema: Sendable {
+    @Guide(description: "Primary food name in singular canonical form (e.g. 'egg', 'banana', 'chicken biryani'). EMPTY STRING when the message is not a food log (weight chart, workout, summary, etc.).")
+    let foodName: String
+    @Guide(description: "Numeric quantity. Use 1 when the user didn't specify. Range 0.01-100.")
+    let quantity: Double
+    @Guide(description: "Unit of measurement, one of: 'grams', 'ounces', 'milliliters', 'cups', 'tablespoons', 'teaspoons', 'pieces', 'slices', 'plates', 'bowls', 'servings'. Use 'servings' as a fallback when the user didn't specify.")
+    let unit: String
+    @Guide(description: "Meal type literal: 'breakfast', 'lunch', 'dinner', or 'snack'. Nil when the user did not name a meal.")
+    let mealType: String?
+    @Guide(description: "Additional foods the user mentioned in the same message; empty array when only one food was named. Compound foods like 'mac and cheese' stay as a single primary, NOT split.")
+    let additionalItems: [Item]
+
+    @Generable
+    struct Item: Sendable {
+        @Guide(description: "Food name in singular canonical form. Do not invent foods the user didn't mention.")
+        let foodName: String
+        @Guide(description: "Numeric quantity for this item. Use 1 when not specified.")
+        let quantity: Double
+        @Guide(description: "Unit literal, same vocabulary as the primary unit.")
+        let unit: String
+    }
+}
+#endif

--- a/DriftCore/Sources/DriftCore/AI/Parsing/AIActionExecutor+FMAsync.swift
+++ b/DriftCore/Sources/DriftCore/AI/Parsing/AIActionExecutor+FMAsync.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+// Async FM-first companions for the food-intent parsers + bridge from the
+// typed `FMFoodLogIntent` shape down to the existing `FoodIntent`. Per
+// design-666 QW1: the FM path is gated by `Preferences.fmFoodIntentExtractEnabled`
+// (kill-switch ON by default). On `.unavailable` / `.notFoodLog` / `.bounded` /
+// session error the async path falls through to the existing regex parsers so
+// callers get the same shape regardless of backend.
+
+// MARK: - Bridge: FMFoodLogIntent → FoodIntent
+
+public enum FoodLogIntentBridge {
+
+    /// Map only the primary item to a single `FoodIntent`. Used by the
+    /// `parseFoodIntent` async companion which expects one intent or nil.
+    public static func toFoodIntent(_ intent: FMFoodLogIntent) -> FoodIntent {
+        return makeIntent(
+            name: intent.foodName,
+            quantity: intent.quantity,
+            unit: intent.unit,
+            mealHint: intent.mealType?.rawValue
+        )
+    }
+
+    /// Map primary + additionals to `[FoodIntent]`. mealHint from the primary
+    /// is inherited by every additional so a "for lunch" suffix tags the
+    /// whole batch (matches the existing regex behaviour where the suffix
+    /// is stripped once and applied per-result downstream).
+    public static func toFoodIntents(_ intent: FMFoodLogIntent) -> [FoodIntent] {
+        let mealHint = intent.mealType?.rawValue
+        let primary = makeIntent(
+            name: intent.foodName,
+            quantity: intent.quantity,
+            unit: intent.unit,
+            mealHint: mealHint
+        )
+        let additionals = intent.additionalItems.map {
+            makeIntent(name: $0.foodName, quantity: $0.quantity, unit: $0.unit, mealHint: mealHint)
+        }
+        return [primary] + additionals
+    }
+
+    // MARK: - Helpers
+
+    /// Trim whitespace and apply the regex parser's plural-singularization
+    /// rule so downstream DB lookup behaves the same for both backends
+    /// ("eggs" → "egg", but short words like "gas" stay).
+    static func singularize(_ raw: String) -> String {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasSuffix("s") && trimmed.count > 3 {
+            return String(trimmed.dropLast())
+        }
+        return trimmed
+    }
+
+    /// Build a `FoodIntent` from a single FM extraction result. Weight /
+    /// volume units route through `AIActionExecutor.normalizeToGrams(_:unit:foodHint:)`
+    /// so food-aware density (honey, butter, oil) hits the bridge the same
+    /// way it hits the regex path. Count units (slices/plates/bowls/servings)
+    /// stay as `servings`; pieces resolve to grams when the food is in the
+    /// known-piece-foods set, else stay as `servings`.
+    private static func makeIntent(
+        name: String,
+        quantity: Double,
+        unit: FMFoodLogIntent.Unit,
+        mealHint: String?
+    ) -> FoodIntent {
+        let singular = singularize(name)
+        switch unit {
+        case .grams:
+            return FoodIntent(query: singular, servings: nil, mealHint: mealHint, gramAmount: quantity)
+        case .ounces:
+            return FoodIntent(query: singular, servings: nil, mealHint: mealHint, gramAmount: quantity * 28.3495)
+        case .milliliters:
+            return FoodIntent(query: singular, servings: nil, mealHint: mealHint, gramAmount: quantity)
+        case .cups:
+            let grams = AIActionExecutor.normalizeToGrams(quantity, unit: "cup", foodHint: singular)
+                ?? (quantity * 240)
+            return FoodIntent(query: singular, servings: nil, mealHint: mealHint, gramAmount: grams)
+        case .tablespoons:
+            let grams = AIActionExecutor.normalizeToGrams(quantity, unit: "tbsp", foodHint: singular)
+                ?? (quantity * 15)
+            return FoodIntent(query: singular, servings: nil, mealHint: mealHint, gramAmount: grams)
+        case .teaspoons:
+            let grams = AIActionExecutor.normalizeToGrams(quantity, unit: "tsp", foodHint: singular)
+                ?? (quantity * 5)
+            return FoodIntent(query: singular, servings: nil, mealHint: mealHint, gramAmount: grams)
+        case .pieces:
+            if let grams = AIActionExecutor.normalizeToGrams(quantity, unit: "piece", foodHint: singular) {
+                return FoodIntent(query: singular, servings: nil, mealHint: mealHint, gramAmount: grams)
+            }
+            return FoodIntent(query: singular, servings: quantity, mealHint: mealHint, gramAmount: nil)
+        case .slices, .plates, .bowls, .servings:
+            return FoodIntent(query: singular, servings: quantity, mealHint: mealHint, gramAmount: nil)
+        }
+    }
+}
+
+// MARK: - AIActionExecutor async companions
+
+extension AIActionExecutor {
+
+    /// FM-first variant of `parseFoodIntent`. When `Preferences.fmFoodIntentExtractEnabled`
+    /// is ON and the platform supports FoundationModels (iOS 26+/macOS 26+),
+    /// the message routes through `FoodLogIntentExtractor`; on `.unavailable`,
+    /// `.notFoodLog`, `.bounded`, or session error the call falls back to the
+    /// regex `parseFoodIntent`. Returns the same `FoodIntent?` shape so
+    /// existing callers don't need to branch on backend.
+    public static func parseFoodIntentAsync(_ text: String) async -> FoodIntent? {
+        guard Preferences.fmFoodIntentExtractEnabled else { return parseFoodIntent(text) }
+        do {
+            let intent = try await FoodLogIntentExtractor.extract(text: text)
+            return FoodLogIntentBridge.toFoodIntent(intent)
+        } catch {
+            return parseFoodIntent(text)
+        }
+    }
+
+    /// FM-first variant of `parseMultiFoodIntent`. Same flag + fallback rules
+    /// as `parseFoodIntentAsync`. Returns nil when the FM result has only the
+    /// primary item (matching the regex contract: multi-intent only when ≥2
+    /// foods are present).
+    public static func parseMultiFoodIntentAsync(_ text: String) async -> [FoodIntent]? {
+        guard Preferences.fmFoodIntentExtractEnabled else { return parseMultiFoodIntent(text) }
+        do {
+            let intent = try await FoodLogIntentExtractor.extract(text: text)
+            let intents = FoodLogIntentBridge.toFoodIntents(intent)
+            return intents.count > 1 ? intents : nil
+        } catch {
+            return parseMultiFoodIntent(text)
+        }
+    }
+}

--- a/DriftCore/Sources/DriftCore/Utilities/Preferences.swift
+++ b/DriftCore/Sources/DriftCore/Utilities/Preferences.swift
@@ -105,6 +105,24 @@ public enum Preferences {
         set { UserDefaults.standard.set(newValue, forKey: fmCompositeFoodExtractKey) }
     }
 
+    private static let fmFoodIntentExtractKey = "drift_fm_food_intent_extract"
+
+    /// When enabled, free-text food-log messages ("ate 2 eggs", "log 1/3
+    /// avocado", "double the rice", "chicken and rice for lunch") route
+    /// through Apple Foundation Models (`@Generable FMFoodLogIntentSchema`)
+    /// on iOS 26+/macOS 26+ before falling back to the regex chain
+    /// (`parseFoodIntent` + `parseMultiFoodIntent` + `extractAmount` +
+    /// `matchIngredient` — ~340 LOC). Per design-666 QW1 — collapses the
+    /// per-stage regex pipeline into one typed call. Kill-switch: flip OFF
+    /// to revert to regex everywhere.
+    public static var fmFoodIntentExtractEnabled: Bool {
+        get {
+            if UserDefaults.standard.object(forKey: fmFoodIntentExtractKey) == nil { return true }
+            return UserDefaults.standard.bool(forKey: fmFoodIntentExtractKey)
+        }
+        set { UserDefaults.standard.set(newValue, forKey: fmFoodIntentExtractKey) }
+    }
+
     // MARK: - Health Nudges
 
     private static let healthNudgesKey = "drift_health_nudges"

--- a/DriftCore/Tests/DriftCoreTests/FoodLogIntentExtractorTests.swift
+++ b/DriftCore/Tests/DriftCoreTests/FoodLogIntentExtractorTests.swift
@@ -1,0 +1,530 @@
+import Foundation
+@testable import DriftCore
+import Testing
+
+// Tier-0 tests for design-666 QW1 unified food-log intent extractor.
+// Pure helpers only — bounds + 10 prompt anchors + flag default + bridge
+// mapping + 40-row gold set + flag-off async↔sync equivalence. The FM-backed
+// Tier-3 gold set lives in DriftLLMEvalMacOS (extension lands separately).
+
+// MARK: - FoodLogIntentBounds — hallucination guard
+
+@Test func foodIntentBounds_simpleClean() {
+    let i = FMFoodLogIntent(foodName: "egg", quantity: 2, unit: .pieces)
+    #expect(FoodLogIntentBounds.violation(in: i) == nil)
+}
+
+@Test func foodIntentBounds_thaliCeilingOK() {
+    // 9 additionals = the realistic ceiling. Should pass.
+    let items = (0..<9).map { FMFoodLogIntent.Item(foodName: "item\($0)", quantity: 1, unit: .servings) }
+    let i = FMFoodLogIntent(foodName: "biryani", quantity: 1, unit: .plates, additionalItems: items)
+    #expect(FoodLogIntentBounds.violation(in: i) == nil)
+}
+
+@Test func foodIntentBounds_emptyFoodNameNotFoodLog() {
+    let i = FMFoodLogIntent(foodName: "", quantity: 1, unit: .servings)
+    #expect(FoodLogIntentBounds.violation(in: i) == .notFoodLog)
+}
+
+@Test func foodIntentBounds_whitespaceFoodNameNotFoodLog() {
+    let i = FMFoodLogIntent(foodName: "   ", quantity: 1, unit: .servings)
+    #expect(FoodLogIntentBounds.violation(in: i) == .notFoodLog)
+}
+
+@Test func foodIntentBounds_rejectZeroQuantity() {
+    let i = FMFoodLogIntent(foodName: "rice", quantity: 0, unit: .grams)
+    #expect(FoodLogIntentBounds.violation(in: i) == .quantityOutOfRange(0))
+}
+
+@Test func foodIntentBounds_rejectImpossibleQuantity() {
+    let i = FMFoodLogIntent(foodName: "rice", quantity: 9999, unit: .grams)
+    #expect(FoodLogIntentBounds.violation(in: i) == .quantityOutOfRange(9999))
+}
+
+@Test func foodIntentBounds_rejectIngredientHallucination() {
+    // FM splitting "chicken biryani" into 10+ ingredient words = hallucination.
+    let items = (0..<10).map { FMFoodLogIntent.Item(foodName: "item\($0)", quantity: 1, unit: .servings) }
+    let i = FMFoodLogIntent(foodName: "biryani", quantity: 1, unit: .plates, additionalItems: items)
+    #expect(FoodLogIntentBounds.violation(in: i) == .tooManyAdditionals(10))
+}
+
+@Test func foodIntentBounds_minQuantityOK() {
+    let i = FMFoodLogIntent(foodName: "saffron", quantity: 0.01, unit: .grams)
+    #expect(FoodLogIntentBounds.violation(in: i) == nil)
+}
+
+@Test func foodIntentBounds_maxQuantityOK() {
+    let i = FMFoodLogIntent(foodName: "grapes", quantity: 100, unit: .pieces)
+    #expect(FoodLogIntentBounds.violation(in: i) == nil)
+}
+
+// MARK: - Feature flag default (serialized — both tests touch one UserDefaults key)
+
+@Suite(.serialized) struct FoodIntentFlagBehavior {
+    private let key = "drift_fm_food_intent_extract"
+
+    @Test func defaultsAndPersistence() {
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        UserDefaults.standard.removeObject(forKey: key)
+        #expect(Preferences.fmFoodIntentExtractEnabled == true,
+                "Per design-666 QW1 the FM food-intent path defaults ON")
+
+        Preferences.fmFoodIntentExtractEnabled = false
+        #expect(Preferences.fmFoodIntentExtractEnabled == false)
+        Preferences.fmFoodIntentExtractEnabled = true
+        #expect(Preferences.fmFoodIntentExtractEnabled == true)
+    }
+
+    @Test func asyncParseFood_flagOffMatchesSync() async {
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        Preferences.fmFoodIntentExtractEnabled = false
+        let input = "ate 2 eggs"
+        let asyncResult = await AIActionExecutor.parseFoodIntentAsync(input)
+        let syncResult = AIActionExecutor.parseFoodIntent(input)
+        #expect(equalIntents(asyncResult, syncResult),
+                "Flag-off async path must match sync regex output exactly")
+    }
+
+    @Test func asyncMultiFood_flagOffMatchesSync() async {
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        Preferences.fmFoodIntentExtractEnabled = false
+        let input = "ate chicken and rice"
+        let asyncResult = await AIActionExecutor.parseMultiFoodIntentAsync(input)
+        let syncResult = AIActionExecutor.parseMultiFoodIntent(input)
+        #expect(equalIntentArrays(asyncResult, syncResult),
+                "Flag-off async multi-food path must match sync regex output exactly")
+    }
+
+    @Test func asyncParseFood_flagOffMatchesSync_allGoldRows() async {
+        // Exhaustive flag-off equivalence: every gold-set row must round-trip
+        // identically through parseFoodIntentAsync vs parseFoodIntent. Pins
+        // the kill-switch guarantee: when fmFoodIntentExtractEnabled is false,
+        // the async path is byte-for-byte the sync regex with zero FM influence.
+        defer { UserDefaults.standard.removeObject(forKey: key) }
+        Preferences.fmFoodIntentExtractEnabled = false
+        for row in foodIntentGoldSet {
+            let asyncResult = await AIActionExecutor.parseFoodIntentAsync(row.input)
+            let syncResult = AIActionExecutor.parseFoodIntent(row.input)
+            #expect(equalIntents(asyncResult, syncResult),
+                    "Flag-off divergence on '\(row.input)' — async=\(intentString(asyncResult)), sync=\(intentString(syncResult))")
+        }
+    }
+}
+
+// MARK: - Prompt anchoring (10 distinct anchor families per design-666 QW1)
+
+@Test func foodIntentPromptCoversCountUnit() {
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("pieces"))
+}
+
+@Test func foodIntentPromptCoversWeightUnit() {
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("grams"))
+}
+
+@Test func foodIntentPromptCoversVolumeUnit() {
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("tbsp") || p.contains("tablespoons"))
+    #expect(p.contains("cup") || p.contains("cups"))
+}
+
+@Test func foodIntentPromptCoversPortionWord() {
+    // "half a banana", "quarter cup oats" — regex stumbles, FM handles.
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("half") || p.contains("quarter"))
+}
+
+@Test func foodIntentPromptCoversFraction() {
+    // "1/3 avocado" — fraction parsing.
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any")
+    #expect(p.contains("1/3") || p.lowercased().contains("0.333"))
+}
+
+@Test func foodIntentPromptCoversMultiplier() {
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("double") || p.contains("triple") || p.contains("2x"))
+}
+
+@Test func foodIntentPromptCoversMealHint() {
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("breakfast"))
+    #expect(p.contains("mealtype"))
+}
+
+@Test func foodIntentPromptCoversCompoundFoodWhitelist() {
+    // Compound foods MUST stay as one — "mac and cheese" → one foodName.
+    // Without this guard the model splits compound dishes into ingredient words.
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("mac and cheese"))
+}
+
+@Test func foodIntentPromptCoversNonFoodSentinel() {
+    // Empty foodName is the "not a food log" signal — must be explicit so the
+    // bounds violation lands instead of synthesizing a bogus log row.
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("empty"))
+    #expect(p.contains("weight chart") || p.contains("workout"))
+}
+
+@Test func foodIntentPromptIncludesInputText() {
+    let unique = "MARKER_\(UUID().uuidString.prefix(8))"
+    let p = FoodLogIntentExtractor.buildPrompt(for: unique)
+    #expect(p.contains(unique))
+}
+
+@Test func foodIntentPromptForbidsInvention() {
+    // FM must not invent foods the user didn't say — strict guardrail since
+    // hallucinated food rows log calories the user never ate.
+    let p = FoodLogIntentExtractor.buildPrompt(for: "any").lowercased()
+    #expect(p.contains("do not invent") || p.contains("don't invent") || p.contains("verbatim"))
+}
+
+// MARK: - FoodLogIntentBridge — unit → FoodIntent mapping
+
+@Test func bridge_gramsStayGrams() {
+    let i = FMFoodLogIntent(foodName: "chicken", quantity: 200, unit: .grams)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.query == "chicken")
+    #expect(out.gramAmount == 200)
+    #expect(out.servings == nil)
+}
+
+@Test func bridge_ouncesConvertToGrams() {
+    let i = FMFoodLogIntent(foodName: "almonds", quantity: 2, unit: .ounces)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    // 2 oz × 28.3495 ≈ 56.7
+    #expect(out.gramAmount.map { abs($0 - 56.699) < 0.01 } ?? false)
+    #expect(out.servings == nil)
+}
+
+@Test func bridge_millilitersStayAsGrams() {
+    let i = FMFoodLogIntent(foodName: "milk", quantity: 100, unit: .milliliters)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.gramAmount == 100)
+}
+
+@Test func bridge_cupsUseFoodAwareDensity() {
+    // 1 cup oats = 80g (gramsPerCup for oats). NOT 240g (flat-cup constant).
+    let i = FMFoodLogIntent(foodName: "oats", quantity: 1, unit: .cups)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.query == "oat")
+    #expect(out.gramAmount == 80, "1 cup oats must use oats density (80g), not flat 240g")
+}
+
+@Test func bridge_cupsUnknownFoodFallback() {
+    // Food not in matchIngredient table → falls back to flat 240g.
+    let i = FMFoodLogIntent(foodName: "tuna", quantity: 1, unit: .cups)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.gramAmount == 240, "Unknown food in cups uses flat 240g fallback")
+}
+
+@Test func bridge_tablespoonsUseFoodAwareDensity() {
+    // 2 tbsp honey = 2 × (340/16) = 42.5g.
+    let i = FMFoodLogIntent(foodName: "honey", quantity: 2, unit: .tablespoons)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.gramAmount.map { abs($0 - 42.5) < 0.01 } ?? false)
+}
+
+@Test func bridge_teaspoonsUseFoodAwareDensity() {
+    // 1 tsp ghee = 1 × (218/48) ≈ 4.54g.
+    let i = FMFoodLogIntent(foodName: "ghee", quantity: 1, unit: .teaspoons)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.gramAmount.map { abs($0 - 4.54) < 0.05 } ?? false)
+}
+
+@Test func bridge_piecesResolveToGramsForKnownFood() {
+    // 2 eggs → 2 × 50g (egg gramsPerPiece) = 100g.
+    let i = FMFoodLogIntent(foodName: "egg", quantity: 2, unit: .pieces)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.gramAmount == 100)
+    #expect(out.servings == nil)
+}
+
+@Test func bridge_piecesUnknownFoodStayAsServings() {
+    // FM said "pieces" but food has no known piece weight (e.g. "samosa")
+    // → keep as servings so downstream still logs *something* sensible.
+    let i = FMFoodLogIntent(foodName: "samosa", quantity: 3, unit: .pieces)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.servings == 3)
+    #expect(out.gramAmount == nil)
+}
+
+@Test func bridge_slicesAreServings() {
+    // 2 slices of bread → 2 servings (slice has no flat gram constant
+    // since bread slice weight varies wildly).
+    let i = FMFoodLogIntent(foodName: "bread", quantity: 2, unit: .slices)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.servings == 2)
+    #expect(out.gramAmount == nil)
+}
+
+@Test func bridge_platesAndBowlsAreServings() {
+    let plate = FoodLogIntentBridge.toFoodIntent(
+        FMFoodLogIntent(foodName: "biryani", quantity: 1, unit: .plates)
+    )
+    #expect(plate.servings == 1)
+    #expect(plate.gramAmount == nil)
+
+    let bowl = FoodLogIntentBridge.toFoodIntent(
+        FMFoodLogIntent(foodName: "dal", quantity: 1, unit: .bowls)
+    )
+    #expect(bowl.servings == 1)
+    #expect(bowl.gramAmount == nil)
+}
+
+@Test func bridge_pluralsSingularized() {
+    // FM might return "eggs" (plural) — bridge singularizes to match
+    // regex parser output and DB lookup expectations.
+    let i = FMFoodLogIntent(foodName: "bananas", quantity: 2, unit: .pieces)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.query == "banana")
+}
+
+@Test func bridge_singularNotMutated() {
+    // Don't singularize words that already are singular (e.g. "rice" ends in 'e').
+    let i = FMFoodLogIntent(foodName: "rice", quantity: 100, unit: .grams)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.query == "rice")
+}
+
+@Test func bridge_shortWordsNotSingularized() {
+    // "gas" is 3 chars — don't strip 's' (would mangle short words).
+    let i = FMFoodLogIntent(foodName: "gas", quantity: 1, unit: .servings)
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.query == "gas")
+}
+
+@Test func bridge_mealHintInheritedByAdditionals() {
+    // "ate eggs and toast for breakfast" — bridge propagates breakfast
+    // mealHint to BOTH the primary egg intent and the toast additional.
+    let i = FMFoodLogIntent(
+        foodName: "egg",
+        quantity: 2,
+        unit: .pieces,
+        mealType: .breakfast,
+        additionalItems: [
+            .init(foodName: "toast", quantity: 1, unit: .slices)
+        ]
+    )
+    let intents = FoodLogIntentBridge.toFoodIntents(i)
+    #expect(intents.count == 2)
+    #expect(intents[0].mealHint == "breakfast")
+    #expect(intents[1].mealHint == "breakfast",
+            "Additional items must inherit mealHint from the primary")
+}
+
+@Test func bridge_nilMealHintNotInjected() {
+    // No mealType from FM → both primary and additionals carry nil mealHint.
+    let i = FMFoodLogIntent(
+        foodName: "egg", quantity: 2, unit: .pieces, mealType: nil,
+        additionalItems: [.init(foodName: "toast", quantity: 1, unit: .slices)]
+    )
+    let intents = FoodLogIntentBridge.toFoodIntents(i)
+    #expect(intents.allSatisfy { $0.mealHint == nil })
+}
+
+@Test func bridge_singleIntent_extractedOnly() {
+    // toFoodIntent returns ONLY the primary — used by parseFoodIntentAsync
+    // which expects a single intent.
+    let i = FMFoodLogIntent(
+        foodName: "chicken", quantity: 1, unit: .servings,
+        additionalItems: [
+            .init(foodName: "rice", quantity: 1, unit: .cups),
+            .init(foodName: "broccoli", quantity: 1, unit: .servings),
+        ]
+    )
+    let out = FoodLogIntentBridge.toFoodIntent(i)
+    #expect(out.query == "chicken")
+}
+
+// MARK: - Gold set — 40 food-log queries (design-666 QW1 deliverable)
+
+/// What the FM extractor should produce (specification), expressed as a
+/// `FoodIntent`. Use `_anyQuantity` when the specific numeric is unstable
+/// across FM revisions — only the shape matters.
+private struct FoodTarget: Equatable, Sendable {
+    let query: String
+    let servings: Double?
+    let gramAmount: Double?
+    let mealHint: String?
+}
+
+/// `match(target)` — regex matches and equals `target` (regex correct today)
+/// `wrong(observed)` — regex returns *something* but differs from target (FM win: correctness)
+/// `miss` — regex returns nil but target is non-nil (FM win: coverage)
+/// `correctlyRejected` — regex returns nil and target is also nil (parity, both punt)
+private enum RegexBaseline: Equatable {
+    case match
+    case wrong(observed: FoodTarget)
+    case miss
+    case correctlyRejected
+}
+
+private struct FoodRow {
+    let input: String
+    let target: FoodTarget?
+    let regexBaseline: RegexBaseline
+}
+
+private let foodIntentGoldSet: [FoodRow] = [
+    // 1-8: counts (regex handles correctly)
+    .init(input: "ate 2 eggs", target: .init(query: "egg", servings: 2, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "log 3 bananas", target: .init(query: "banana", servings: 3, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "had 4 chapatis", target: .init(query: "chapati", servings: 4, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate 5 dosas", target: .init(query: "dosa", servings: 5, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate eggs", target: .init(query: "egg", servings: nil, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "log paneer", target: .init(query: "paneer", servings: nil, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "had toast", target: .init(query: "toast", servings: nil, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate one egg", target: .init(query: "egg", servings: 1, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+
+    // 9-13: weights (regex handles correctly)
+    .init(input: "log 200g chicken", target: .init(query: "chicken", servings: nil, gramAmount: 200, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate 100g paneer", target: .init(query: "paneer", servings: nil, gramAmount: 100, mealHint: nil), regexBaseline: .match),
+    .init(input: "log 2 oz almonds", target: .init(query: "almond", servings: nil, gramAmount: 56.699, mealHint: nil), regexBaseline: .match),
+    .init(input: "had 50g rice", target: .init(query: "rice", servings: nil, gramAmount: 50, mealHint: nil), regexBaseline: .match),
+    .init(input: "log 1kg oats", target: .init(query: "oat", servings: nil, gramAmount: 1000, mealHint: nil), regexBaseline: .match),
+
+    // 14-18: volumes (regex handles correctly with food-aware density)
+    .init(input: "log 1 cup oats", target: .init(query: "oat", servings: nil, gramAmount: 80, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate 2 tbsp honey", target: .init(query: "honey", servings: nil, gramAmount: 42.5, mealHint: nil), regexBaseline: .match),
+    .init(input: "log 1 tsp ghee", target: .init(query: "ghee", servings: nil, gramAmount: 218.0 / 48.0, mealHint: nil), regexBaseline: .match),
+    .init(input: "had 100ml milk", target: .init(query: "milk", servings: nil, gramAmount: 100, mealHint: nil), regexBaseline: .match),
+    .init(input: "log 1 cup rice", target: .init(query: "rice", servings: nil, gramAmount: 185, mealHint: nil), regexBaseline: .match),
+
+    // 19-23: fractions / portion words
+    .init(input: "log 1/3 avocado", target: .init(query: "avocado", servings: 1.0 / 3.0, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate half a banana",
+          target: .init(query: "banana", servings: 0.5, gramAmount: nil, mealHint: nil),
+          regexBaseline: .wrong(observed: .init(query: "a banana", servings: 0.5, gramAmount: nil, mealHint: nil))),
+    .init(input: "log a quarter cup oats", target: .init(query: "oat", servings: nil, gramAmount: 20, mealHint: nil), regexBaseline: .match),
+    .init(input: "log a couple of eggs", target: .init(query: "egg", servings: 2, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate a few almonds", target: .init(query: "almond", servings: 3, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+
+    // 24-27: multipliers
+    .init(input: "log double the rice", target: .init(query: "rice", servings: 2, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate 2x chicken", target: .init(query: "chicken", servings: 2, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "log triple the eggs", target: .init(query: "egg", servings: 3, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "ate twice the dal", target: .init(query: "dal", servings: 2, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+
+    // 28-31: meal hints
+    .init(input: "log eggs for breakfast", target: .init(query: "egg", servings: nil, gramAmount: nil, mealHint: "breakfast"), regexBaseline: .match),
+    .init(input: "ate rice for lunch", target: .init(query: "rice", servings: nil, gramAmount: nil, mealHint: "lunch"), regexBaseline: .match),
+    .init(input: "had dal for dinner", target: .init(query: "dal", servings: nil, gramAmount: nil, mealHint: "dinner"), regexBaseline: .match),
+    .init(input: "log paneer for snack", target: .init(query: "paneer", servings: nil, gramAmount: nil, mealHint: "snack"), regexBaseline: .match),
+
+    // 32-34: compound-food whitelist — must stay as one foodName, not split
+    .init(input: "ate mac and cheese", target: .init(query: "mac and cheese", servings: nil, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "had peanut butter and jelly", target: .init(query: "peanut butter and jelly", servings: nil, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+    .init(input: "log bread and butter", target: .init(query: "bread and butter", servings: nil, gramAmount: nil, mealHint: nil), regexBaseline: .match),
+
+    // 35-37: non-food sentinels — both regex and FM should return nil
+    .init(input: "show me my weight chart", target: nil, regexBaseline: .correctlyRejected),
+    .init(input: "log my weight", target: nil, regexBaseline: .correctlyRejected),
+    .init(input: "what did I eat yesterday", target: nil, regexBaseline: .correctlyRejected),
+
+    // 38-40: regex misses (no verb prefix or unknown unit) — FM should succeed
+    .init(input: "200g chicken",
+          target: .init(query: "chicken", servings: nil, gramAmount: 200, mealHint: nil),
+          regexBaseline: .miss),
+    .init(input: "a plate of biryani",
+          target: .init(query: "biryani", servings: 1, gramAmount: nil, mealHint: nil),
+          regexBaseline: .miss),
+    .init(input: "a bowl of dal",
+          target: .init(query: "dal", servings: 1, gramAmount: nil, mealHint: nil),
+          regexBaseline: .miss),
+]
+
+@Test func foodGoldSet_hasFortyQueries() {
+    #expect(foodIntentGoldSet.count == 40,
+            "design-666 QW1 deliverable specifies 40 food-log gold queries")
+}
+
+@Test func foodGoldSet_regexBaselineMatchesReality() {
+    // For every gold-set row, the current regex output must agree with the
+    // recorded `regexBaseline`. This pins what the regex does today so a
+    // future regex tweak can't silently shift the FM-vs-regex split.
+    for row in foodIntentGoldSet {
+        let observed = AIActionExecutor.parseFoodIntent(row.input)
+        switch row.regexBaseline {
+        case .match:
+            guard let target = row.target else {
+                #expect(Bool(false), "Row '\(row.input)' marked .match but target is nil")
+                continue
+            }
+            #expect(intentMatchesTarget(observed, target),
+                    "Regex baseline drift on '\(row.input)' — expected match \(target), got \(intentString(observed))")
+        case .wrong(let observedTarget):
+            #expect(intentMatchesTarget(observed, observedTarget),
+                    "Regex baseline drift on '\(row.input)' — recorded wrong-output \(observedTarget), got \(intentString(observed))")
+        case .miss:
+            #expect(observed == nil,
+                    "Regex baseline drift on '\(row.input)' — recorded miss, got \(intentString(observed))")
+        case .correctlyRejected:
+            #expect(observed == nil,
+                    "Regex baseline drift on '\(row.input)' — recorded correctly-rejected, got \(intentString(observed))")
+        }
+    }
+}
+
+@Test func foodGoldSet_fmWinsCoverDistinctCategories() {
+    // The FM-vs-regex delta is the QW1 win surface. Make sure the gold set
+    // covers BOTH win categories — regex coverage gaps (no-verb, unknown
+    // units) and regex correctness errors (portion-word stumbles). If we
+    // drop below this floor the gold set isn't actually testing the migration.
+    let misses = foodIntentGoldSet.filter { if case .miss = $0.regexBaseline { return true } else { return false } }
+    let wrongs = foodIntentGoldSet.filter { if case .wrong = $0.regexBaseline { return true } else { return false } }
+    let rejects = foodIntentGoldSet.filter { if case .correctlyRejected = $0.regexBaseline { return true } else { return false } }
+    #expect(misses.count >= 2, "Need ≥2 regex-miss rows so FM coverage gain is measurable")
+    #expect(wrongs.count >= 1, "Need ≥1 regex-wrong row so FM correctness gain is measurable")
+    #expect(rejects.count >= 2, "Need ≥2 non-food rows so the bounds check is exercised")
+}
+
+// MARK: - Helpers
+
+private func equalIntents(_ a: FoodIntent?, _ b: FoodIntent?) -> Bool {
+    switch (a, b) {
+    case (nil, nil): return true
+    case (let l?, let r?):
+        return l.query == r.query
+            && l.servings == r.servings
+            && l.mealHint == r.mealHint
+            && l.gramAmount == r.gramAmount
+    default: return false
+    }
+}
+
+private func equalIntentArrays(_ a: [FoodIntent]?, _ b: [FoodIntent]?) -> Bool {
+    switch (a, b) {
+    case (nil, nil): return true
+    case (let l?, let r?):
+        guard l.count == r.count else { return false }
+        return zip(l, r).allSatisfy { equalIntents($0, $1) }
+    default: return false
+    }
+}
+
+private func intentMatchesTarget(_ intent: FoodIntent?, _ target: FoodTarget) -> Bool {
+    guard let i = intent else { return false }
+    guard i.query == target.query else { return false }
+    guard nearlyEqual(i.servings, target.servings) else { return false }
+    guard nearlyEqual(i.gramAmount, target.gramAmount) else { return false }
+    guard i.mealHint == target.mealHint else { return false }
+    return true
+}
+
+private func nearlyEqual(_ a: Double?, _ b: Double?) -> Bool {
+    switch (a, b) {
+    case (nil, nil): return true
+    case (let l?, let r?): return abs(l - r) < 0.01
+    default: return false
+    }
+}
+
+private func intentString(_ intent: FoodIntent?) -> String {
+    guard let i = intent else { return "nil" }
+    let servingsStr = i.servings.map { String($0) } ?? "nil"
+    let gramsStr = i.gramAmount.map { String($0) } ?? "nil"
+    let mealStr = i.mealHint ?? "nil"
+    return "FoodIntent(query=\(i.query), servings=\(servingsStr), grams=\(gramsStr), meal=\(mealStr))"
+}


### PR DESCRIPTION
## Summary
- Daily exec briefing for 2026-05-14. Headline: FoodLogIntent unified extractor lands (design-666 QW1).
- Calls out the 4-days-running exec-briefing hook noise as the top non-product blocker.

## Test plan
- [x] File renders cleanly in the GitHub PR view
- [x] Matches EXEC-TEMPLATE.md sections (Headline, Snapshot, Shipped, Working Well, Risks, Focus, Cost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)