### PR TITLE
report: daily exec briefing 2026-05-26

### DIFF
--- a/Docs/reports/exec-2026-05-26.md
+++ b/Docs/reports/exec-2026-05-26.md
@@ -1,0 +1,50 @@
+# Drift Daily Briefing — 2026-05-26
+
+## Headline
+Harness rewritten end-to-end (planning phases 2a→3d) into spec-driven epics + routine-fix junior band; build 273 shipped with V7 Phase 2 donut hero #819 and Snap/Search/food-diary fixes — first single-epic planning cycle starts today.
+
+## Product Snapshot
+Drift is an AI-first health tracker — users type what they ate or did, AI handles logging, tracking, and insights. On-device, no cloud. Currently in closed beta on TestFlight.
+
+| | |
+|---|---|
+| Beta Build | 273 (shipped 2026-05-26) |
+| Test Suite | ~1219 iOS + ~913 DriftCore (~8s warm) + LLM eval |
+| AI Capabilities | 35 registered tools + 11 analytical engines |
+| Food Database | 5,420 (ceiling 6,000) |
+
+## What Shipped This Period
+- **V7 Phase 2 Today donut hero (#819)** — Final Phase 2 P0 closed; 3 concentric rings (kcal coral / protein green / fiber blue) with center kcal number landed. Phase 2 interior IA now fully assembled with last sprint's meal timeline + body summary cards + log methods row.
+- **Food UX fix sweep** — `+ Add food` inline button now opens Search mode (was defaulting wrong), Snap-first-tap race fixed, food-diary dates scrollable, per-piece serving misalignment corrected (TJ meatballs case) with tripwire test pinned.
+- **V7 visibility + density polish** — Today meal timeline compressed to single card with hairlines; pink-fatigue tone-down across cards; pillBackground visibility on tab bar; sheet-refresh field-bug sweep + hardcoded-white lint cleanup.
+- **TestFlight builds 272 + 273** — Two builds in three days carrying user-visible V7 work, not process churn.
+- **Autopilot harness rewrite (phases 2a–3d)** — Planning now emits ONE spec-driven epic with `<done_when>` criteria per cycle (was 8+ standalone tasks); routine-fix junior band auto-drains orphan bugs; `/ui-evaluator` skill scores Drift UI commits against `<visual_criteria>`; `/admin-replies` and `/knowledge-curate` extracted to their own cron-driven slots to free planning's token budget for actual research.
+
+## What's Working Well
+- **V7 Phase 2 fully landed** — All four subprojects (donut hero, meal timeline, body summary cards, log methods row) shipped in ~6 days from filing. Today screen is now wholly V7 internals.
+- **Harness investment paying back as it lands** — Six phase commits in a row (no rollbacks); each phase narrows planning's responsibility while widening the always-on junior worker's drain rate. First clean test of the new shape (single epic + auto-promoted routine-fixes) starts this cycle.
+- **Real UX bug fixes shipping with V7 cosmetic work** — TJ meatballs serving math, food-diary date scroll, Add-food default mode — these were quiet papercuts that surfaced once the new IA exposed them. Catch + fix in same window is the right rhythm.
+
+## Risks & Blockers
+- **Zero admin comments across 5 consecutive daily reports** (#846, #844, #841, #816, #800) — same call-out as 2026-05-23 brief. If the reports aren't being read, the cadence is theater; if they are and nothing is sparking feedback, the headlines are too soft. Either way it's a 2-cycle pattern now, worth a calibration pass.
+- **State.md still pinned at build 234** while live build is 273 — drift is 39 builds wide. Snapshot doc planning reads can't be trusted for build counts; first single-epic cycle should include a State.md refresh sub-task or auto-routed routine-fix.
+- **First single-epic cycle is unproven** — Today is the first planning run under the strict-one-epic harness (phases 2a/3a). If epic-sized scoping is wrong, the next 2 cycles will reveal whether senior queue drains evenly or piles up; watch for stuck-epic override at cycle 14716.
+
+## Focus for Next Period
+1. **First single-epic arc** — Scope from V7 polish + visibility/lifecycle/density bug sweep (#849 already filed). Validate that 5-7 sub-tasks is a one-cycle drain for the senior queue.
+2. **State.md + failing-queries snapshot refresh** — Bring docs to build 273 truth; either as routine-fix or epic sub-task.
+3. **AI chat depth next lever** — V7 Phase 2 done means the next arc can return focus to chat-depth: FM-driven extraction beyond chat (free-text food parsing, exercise transcript), per-screen nav-bar chat icon, or multi-turn reliability gate. Pick one per tenet #0 ("AI chat is the showstopper").
+
+## Cost
+| | |
+|---|---|
+| Model | Opus 4.7 |
+| Sessions today | tracked in token-usage.sh |
+| Est. cost today | tracked in token-usage.sh |
+| Cost/cycle | tracked across cycles in token-usage.sh |
+
+## Decision Needed
+- **Are daily exec briefings reaching anyone?** 5 reports + 0 comments suggests either the audience isn't subscribed or the format isn't surfacing decision-grade asks. Worth a one-line confirmation that the cadence should continue at daily, drop to 2-3x weekly, or switch format (e.g., only file when there's a real ask).
+
+---
+Comment on any line for strategic feedback. @ashish-sadh


### PR DESCRIPTION
Daily exec briefing for 2026-05-26.

Headline: Harness rewritten end-to-end into spec-driven epics + routine-fix junior band; build 273 shipped V7 Phase 2 donut hero #819 and food UX fixes — first single-epic planning cycle starts today.

See Docs/reports/exec-2026-05-26.md for full briefing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)