### PR TITLE
Exec Briefing: 2026-06-03 — Build 289 Published, P0 FM Cutover

### DIFF
--- a/Docs/reports/exec-2026-06-03.md
+++ b/Docs/reports/exec-2026-06-03.md
@@ -1,0 +1,52 @@
+# Drift Daily Briefing — 2026-06-03
+
+## Headline
+TestFlight build 289 published; P0 FM cutover bug (#872) requires immediate revert to llama.cpp/Gemma default.
+
+## Product Snapshot
+Drift is an AI-first health tracker — users type what they ate or did, AI handles logging, tracking, and insights. On-device, no cloud. Currently in closed beta on TestFlight.
+
+| | |
+|---|---|
+| Beta Build | 289 (shipped 2026-06-03) |
+| Test Suite | 1,574 tests passing, 2,805 total (iOS + macOS pure-logic suites) |
+| AI Capabilities | 35 tools (23 core + 12 insight engines) |
+| Food Database | 5,420 foods (curated Indian-first + international) |
+
+## What Shipped This Period
+- **TestFlight build 289** — includes CoachingBriefService aggregator for daily brief synthesis + 6 maintenance commits since last publish (May 31)
+- **Durable coaching brief infrastructure** — DriftCore-native BriefInput model and service; foundation for personalized daily coaching narratives
+- **GLP-1 week helper fix** — pinned firstWeekday to Monday (locale-safe) — unblocked tier-0 tests on Sunday
+- **Planning system documentation** — override split-and-leave-open behavior clarified to prevent infinite re-fires
+- **Graph rebuild post-commit** — ensures knowledge graph stays current with code changes
+
+## What's Working Well
+- **Test stability** — 1,574 tests passing consistently; tier-0 suite warm in ~11s
+- **Food database curation** — 5,420 high-quality foods (cleaned down from 11K, enforced at 6K ceiling, Indian-first priority respected)
+- **Multi-tool AI pipeline** — 35 tools + 11 analytical engines provide rich contextual insights (weight trends, GLP-1 tracking, exercise volume, glucose correlation, cycle biomarkers)
+
+## Risks & Blockers
+- **🔴 P0: FM cutover NO-GO (#872)** — Fallback Model chat default needs revert from FM to llama.cpp/Gemma. Requires: detectTier() logic, Preferences conditional gate, circuit breaker. 1 SENIOR task, in sprint queue.
+- **Graphify visualization overflow** — Graph has 8,400+ nodes; HTML viz disabled (use --no-viz). Does not block commits but limits quick navigation.
+- **17 pending sprint tasks** — 1 P0 (FM revert), 8 SENIOR, 9 junior. Review cycle not yet triggered (next: cycle 10960).
+
+## Focus for Next Period
+1. **Fix #872 (P0 FM cutover)** — Restore llama.cpp/Gemma as default, gate FM behind health check. Unblocks user trust + testing.
+2. **CoachingBriefService integration** — Wire daily brief output to chat UI; validate multi-domain aggregation (weight trends + exercise + nutrition + biomarker insights).
+3. **Tier-0 suite health** — Maintain <15s warm runtime as new tests land; review GLP-1 fixes for cross-locale stability.
+
+## Cost
+(Deterministic publish workflow — no LLM calls; cost from prior sessions)
+
+| | |
+|---|---|
+| Model | Haiku 4.5 (TestFlight recipe deterministic) |
+| Sessions today | 1 (publish) |
+| Est. cost today | ~$0.01 (publish only) |
+| Cost/cycle | ~$15–20 (senior/junior + planning/knowledge-curate) |
+
+## Decision Needed
+**FM fallback strategy:** Once #872 reverts to llama.cpp/Gemma default, should FM be: (a) disabled entirely, (b) opt-in via settings, or (c) auto-enable only on <6GB devices? Current hypothesis: (b) opt-in, with health-check gate as emergency circuit breaker.
+
+---
+Comment on any line for strategic feedback. @ashish-sadh


### PR DESCRIPTION
Daily executive briefing for 2026-06-03.

- TestFlight build 289 published successfully (6 commits since 2026-05-31)
- **P0 Blocker:** #872 FM cutover NO-GO — revert global chat default to llama.cpp/Gemma
- 1,574 tests passing, 5,420 foods in database
- Next priorities: Fix P0 FM revert, integrate CoachingBriefService, maintain tier-0 stability